### PR TITLE
LLM-9: Fix `.github/workflows/deploy_to_pypi.yaml` (deploy to PyPI) GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy_to_pypi.yaml
+++ b/.github/workflows/deploy_to_pypi.yaml
@@ -47,13 +47,13 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --locked
-
-      - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+        run: |
+          uv sync --locked
+          source .venv/bin/activate
 
       - name: Install twine & build package
         run: |
-          pip install build twine
+          uv pip install build twine
           python -m build
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Previously it would crash on the build stage