### PR TITLE
fix: handle release flag

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -57,4 +57,4 @@ jobs:
           git push -u origin release-${{ github.event.inputs.version }}
           gh pr create -a ${{ github.event.sender }} --title "v${{ github.event.inputs.version }}" \
             --body "${{ github.event.inputs.message }}" \
-            --label "${{ github.event.inputs.test && 'test' || 'release' }}"
+            --label "${{ github.event.inputs.test == 'true' && 'test' || 'release' }}"


### PR DESCRIPTION
## Summary
- fix release PR label when `test` flag is disabled

## Testing
- `ruff check .`
- `pyright` *(fails: Import "torch" could not be resolved)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_b_683ea9d78c008331bc0648decaa01c40