### PR TITLE
LLM-28: Add `trust_remote_code` argument of `True` for `nvidia/` models

### DIFF
--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -115,6 +115,9 @@ def load_model_and_tokenizer(
     if not tokenizer.pad_token:
         tokenizer.pad_token = tokenizer.eos_token
 
+    model_by_nvidia = model_name.startswith("nvidia/")
+    trust_remote_code = True if model_by_nvidia else False
+
     if use_4bit:
         # Prepare the quantization configuration for 4-bit loading.
         quantization_config = BitsAndBytesConfig(
@@ -128,6 +131,7 @@ def load_model_and_tokenizer(
             torch_dtype=dtype,
             device_map=device_map,
             quantization_config=quantization_config,
+            trust_remote_code=trust_remote_code,
         )
     else:
         model = AutoModelForCausalLM.from_pretrained(
@@ -135,6 +139,7 @@ def load_model_and_tokenizer(
             torch_dtype=dtype,
             device_map=device_map,
             low_cpu_mem_usage=True,
+            trust_remote_code=trust_remote_code,
         )
 
     return tokenizer, model


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets trust_remote_code=True when loading nvidia/* models and forwards it to from_pretrained in both 4-bit and standard paths.
> 
> - **Model loading**:
>   - Set `trust_remote_code=True` for `nvidia/*` models and pass `trust_remote_code` to `AutoModelForCausalLM.from_pretrained` in both 4-bit and standard code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fbc389f17d15f0e88e4aba1ff1a6e2717ef403. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->