### PR TITLE
LLM-36: Fix cleanup of VRAM of judge model part II

### DIFF
--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -503,11 +503,12 @@ class FreeTextSharedEvaluator(BaseEvaluator):
         judge_pipeline: TextGenerationPipeline | None,
         judge_model: PreTrainedModel | None,
     ) -> None:
-        if hasattr(judge_pipeline, "model"):
-            judge_pipeline.model.cpu()
-            del judge_pipeline.model
-        if hasattr(judge_pipeline, "tokenizer"):
-            del judge_pipeline.tokenizer
+        if judge_pipeline:
+            if hasattr(judge_pipeline, "model"):
+                judge_pipeline.model.cpu()
+                del judge_pipeline.model
+            if hasattr(judge_pipeline, "tokenizer"):
+                del judge_pipeline.tokenizer
         del judge_pipeline
         if judge_model is not None:
             judge_model.cpu()


### PR DESCRIPTION
It looks like the issue primarily was that the judge model was not moved to the CPU first, but this change also ensure that there are no remaining references before running CUDA cache clean and GC collect

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances judge pipeline cleanup to fully free VRAM and logs dataset info alongside results.
> 
> - **FreeText judge management**:
>   - Update `free_judge` to accept `judge_pipeline | None` and `judge_model | None`, move models to CPU, delete model/tokenizer refs, clear tokenizer, and trigger CUDA/GC cleanup.
>   - Track `judge_model` in `judge_pipeline_context` and ensure cleanup via updated `free_judge` when either pipeline or model exists.
> - **Type hints**:
>   - Add `PreTrainedModel` to TYPE_CHECKING imports.
> - **Logging**:
>   - Log dataset slug and dataset type before writing results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31e2907b1c18701777bdea48d366ba1bf77f2828. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->