### PR TITLE
LLM-45: Add support for `no_think` for Nemotron models

### DIFF
--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -108,7 +108,12 @@ class SafeApplyChatTemplate:
                 messages[0]["content"] = f"{sys_msg}\n\n{messages[0]['content']}"
             else:
                 messages.insert(0, {"role": "user", "content": sys_msg})
-        elif uses_nothink and not reasoning:
+        elif (
+            uses_nothink
+            and not reasoning
+            and messages
+            and messages[0]["role"] == "system"
+        ):
             messages[0]["content"] = f"/no_think {messages[0]['content']}"
 
         # Choose formatting based on whether the model is multimodal


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prepend `/no_think` to the first user message when supported by the tokenizer chat template and reasoning is disabled.
> 
> - **Evaluation Utils (`llm_behavior_eval/evaluation_utils/util_functions.py`)**:
>   - **Chat template handling**:
>     - Detects chat templates containing `"/no_think"` and, when `reasoning=False`, prepends `"/no_think "` to the first user message before applying the template.
>     - Retains existing Gemma v1 system-message merging logic.
>   - Keeps compatibility logic for tokenizers with/without `reasoning` kwarg support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fadbbe66089e9a1adad7874d374700c8b09ae168. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->