### PR TITLE
LLM-46: Bug fix: Remove unsupported vllm args. in `LLM`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct prompt-injection
 - `--model-token` / `--judge-token` — supply Hugging Face credentials for the evaluated or judge models (the judge token defaults to the model token when omitted).
 - `--judge-model` — pick a different judge checkpoint; the default is `google/gemma-3-12b-it`.
 - `--inference-engine vllm` / `--inference-engine transformers` — switch between vLLM and transformers backends for the evaluated model. There are also `--model-engine` and `--judge-engine` flags for more explicit control.
+- `--vllm-tokenizer-mode`, `--vllm-config-format`, `--vllm-load-format` — forward advanced knobs directly to the underlying vLLM engine when you need to align tokenizer behavior, checkpoint formats, or tool-calling semantics with a particular deployment. Tokenizer mode accepts `auto`, `slow`, `mistral`, or `custom`.
 - `--reasoning/--no-reasoning` — enable chat-template reasoning modes on tokenizers that support them.
 - `--use-mlflow` plus `--mlflow-tracking-uri`, `--mlflow-experiment-name`, and `--mlflow-run-name` — configure MLflow tracking for the run.
 

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -210,6 +210,27 @@ def main(
             help="Maximum model length for vLLM judge (optional). Defaults to the same value as model inference",
         ),
     ] = None,
+    vllm_tokenizer_mode: Annotated[
+        TokenizerModeOption | None,
+        typer.Option(
+            "--vllm-tokenizer-mode",
+            help="Tokenizer mode forwarded to vLLM (e.g. 'auto', 'slow').",
+        ),
+    ] = None,
+    vllm_config_format: Annotated[
+        str | None,
+        typer.Option(
+            "--vllm-config-format",
+            help="Model config format hint forwarded to vLLM.",
+        ),
+    ] = None,
+    vllm_load_format: Annotated[
+        str | None,
+        typer.Option(
+            "--vllm-load-format",
+            help="Checkpoint load format hint forwarded to vLLM.",
+        ),
+    ] = None,
     reasoning: Annotated[
         bool,
         typer.Option(
@@ -374,6 +395,9 @@ def main(
                 judge_max_model_len=vllm_judge_max_model_len
                 if vllm_judge_max_model_len is not None
                 else vllm_max_model_len,
+                tokenizer_mode=vllm_tokenizer_mode,
+                config_format=vllm_config_format,
+                load_format=vllm_load_format,
             )
         else:
             vllm_config = None

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -280,6 +280,9 @@ def load_vllm_model(
     enforce_eager: bool = False,
     quantization: VLLMQuantization | None = None,
     max_model_len: int | None = None,
+    tokenizer_mode: TokenizerModeOption | None = None,
+    config_format: str | None = None,
+    load_format: str | None = None,
 ) -> LLM:
     """Load a vLLM model engine.
 
@@ -293,6 +296,9 @@ def load_vllm_model(
         enforce_eager: Whether to enforce eager execution (useful for CPU-only setups).
         quantization: Optional quantization backend (for example ``"bitsandbytes"`` for 4-bit inference).
         max_model_len: Optional maximum model length passed to vLLM.
+        tokenizer_mode: Optional tokenizer mode string forwarded to vLLM.
+        config_format: Optional config format string forwarded to vLLM.
+        load_format: Optional checkpoint load format string forwarded to vLLM.
 
     Returns:
         An initialized ``vllm.LLM`` instance.
@@ -312,6 +318,7 @@ def load_vllm_model(
         gpu_count = torch.cuda.device_count()
         tensor_parallel = gpu_count if gpu_count > 0 else None
 
+    default_tokenizer_mode = _get_default_from_vllm("tokenizer_mode")
     default_tensor_parallel = _get_default_from_vllm("tensor_parallel_size")
 
     llm_instance = LLM(
@@ -326,6 +333,9 @@ def load_vllm_model(
         max_num_seqs=batch_size,
         hf_token=token,
         max_model_len=max_model_len,
+        tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
+        config_format=config_format,
+        load_format=load_format,
     )
     return llm_instance
 

--- a/llm_behavior_eval/evaluation_utils/vllm_config.py
+++ b/llm_behavior_eval/evaluation_utils/vllm_config.py
@@ -15,7 +15,13 @@ class VllmConfig(BaseModel):
         max_model_len: Maximum model length for vLLM model inference (optional).
         judge_max_model_len: Maximum model length for vLLM judge inference (optional).
             Defaults to the same value as max_model_len if not specified.
+        tokenizer_mode: Tokenizer mode forwarded to vLLM (e.g. 'auto', 'slow', 'mistral', 'custom').
+        config_format: Model config format hint forwarded to vLLM (optional).
+        load_format: Checkpoint load format hint forwarded to vLLM (optional).
     """
 
     max_model_len: int | None = None
     judge_max_model_len: int | None = None
+    tokenizer_mode: TokenizerModeOption | None = None
+    config_format: str | None = None
+    load_format: str | None = None

--- a/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
+++ b/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
@@ -50,6 +50,9 @@ class VllmEvalEngine(EvalEngine):
         quantization = "bitsandbytes" if use_4bit else None
         # Extract vLLM configuration
         vllm_config = eval_config.vllm_config
+        tokenizer_mode = vllm_config.tokenizer_mode if vllm_config else None
+        config_format = vllm_config.config_format if vllm_config else None
+        load_format = vllm_config.load_format if vllm_config else None
 
         self.model = load_vllm_model(
             model_path_or_repo_id,
@@ -60,6 +63,9 @@ class VllmEvalEngine(EvalEngine):
             enforce_eager=not torch.cuda.is_available(),
             quantization=quantization,
             max_model_len=max_model_len,
+            tokenizer_mode=tokenizer_mode,
+            config_format=config_format,
+            load_format=load_format,
         )
         self._vllm_sampling_params = None
 

--- a/tests/test_eval_engines.py
+++ b/tests/test_eval_engines.py
@@ -346,6 +346,30 @@ def test_vllm_eval_engine_sampling_overrides_config(vllm_bundle, tmp_path) -> No
     assert call_kwargs["seed"] == 99
 
 
+@pytest.mark.vllm_engine_test
+def test_vllm_eval_engine_passes_optional_kwargs(vllm_bundle, tmp_path) -> None:
+    from llm_behavior_eval.evaluation_utils.vllm_config import VllmConfig
+
+    vllm_config = VllmConfig(
+        tokenizer_mode="slow",
+        config_format="hf-torch",
+        load_format="dummy",
+    )
+    config = EvaluationConfig(
+        model_path_or_repo_id="fake/model",
+        results_dir=tmp_path,
+        model_engine="vllm",
+        vllm_config=vllm_config,
+    )
+
+    VllmEvalEngine(config)
+
+    last_call = vllm_bundle.model_loader.calls[-1]["kwargs"]
+    assert last_call["tokenizer_mode"] == "slow"
+    assert last_call["config_format"] == "hf-torch"
+    assert last_call["load_format"] == "dummy"
+
+
 @pytest.mark.transformers_engine_test
 def test_transformers_eval_engine_generate_answers(
     transformers_bundle, tmp_path

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -116,9 +116,15 @@ def test_main_passes_vllm_optional_args(
         "fake/model",
         "hallu",
         inference_engine="vllm",
+        vllm_tokenizer_mode="slow",
+        vllm_config_format="hf",
+        vllm_load_format="safetensors",
     )
     eval_config = capture_eval_config[-1]
     assert eval_config.vllm_config is not None
+    assert eval_config.vllm_config.tokenizer_mode == "slow"
+    assert eval_config.vllm_config.config_format == "hf"
+    assert eval_config.vllm_config.load_format == "safetensors"
 
 
 def test_main_does_not_create_vllm_config_when_not_using_vllm(
@@ -128,6 +134,7 @@ def test_main_does_not_create_vllm_config_when_not_using_vllm(
         "fake/model",
         "hallu",
         model_engine="transformers",
+        vllm_tokenizer_mode="slow",
     )
     eval_config = capture_eval_config[-1]
     assert eval_config.vllm_config is None


### PR DESCRIPTION
removed unsupported vllm args.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops unsupported vLLM advanced options across CLI/config/engine, retaining only max model length settings; updates README and tests accordingly.
> 
> - **vLLM configuration and CLI**:
>   - Remove unsupported vLLM options (`tokenizer_mode`, `config_format`, `load_format`, `tool_call_parser`, `enable_auto_tool_choice`) from `evaluate.py` and `VllmConfig`.
>   - Retain only `vllm_max_model_len` and `vllm_judge_max_model_len`.
> - **vLLM engine/utilities**:
>   - Update `load_vllm_model` signature and instantiation to drop removed kwargs.
>   - Simplify `VllmEvalEngine` to stop reading/forwarding those options.
> - **Tests**:
>   - Remove tests asserting the deleted vLLM kwargs; keep/adjust tests for max model lengths and general behavior.
> - **Docs**:
>   - Update `README.md` CLI options to remove mention of the advanced vLLM flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aad1b107b00f05376adf370551ee2066957694b0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->