### PR TITLE
LLM-48: Fix broken support for `okenizer.chat_template=None`

### DIFF
--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -95,9 +95,13 @@ class SafeApplyChatTemplate:
 
         is_gemma_v1 = (
             tokenizer.name_or_path.startswith("google/gemma-")
+            and isinstance(tokenizer.chat_template, str)
             and "System role not supported" in tokenizer.chat_template
         )
-        uses_nothink = isinstance(tokenizer.chat_template, str) and "/no_think" in tokenizer.chat_template
+        uses_nothink = (
+            isinstance(tokenizer.chat_template, str)
+            and "/no_think" in tokenizer.chat_template
+        )
 
         if is_gemma_v1 and messages and messages[0]["role"] == "system":
             # merge system into next user turn or retag


### PR DESCRIPTION
fixed bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard '/no_think' detection by ensuring `tokenizer.chat_template` is a string, preventing errors when it is `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 243e7d72308ad803e40c07bbb7c44f47141cf22f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->