### PR TITLE
LLM-50: Fix duplicate `\no_think` token insertions into default system message

### DIFF
--- a/llm_behavior_eval/evaluation_utils/custom_dataset.py
+++ b/llm_behavior_eval/evaluation_utils/custom_dataset.py
@@ -1,4 +1,5 @@
 import logging
+from copy import copy
 from functools import partial
 from pathlib import Path
 from typing import cast
@@ -63,7 +64,7 @@ def free_text_preprocess_function(
         system_msg = (
             {"role": "system", "content": system_override}
             if system_override
-            else SYSTEM_PROMPT_DICT
+            else copy(SYSTEM_PROMPT_DICT)
         )
         eval_strings.append(
             safe_apply_chat_template(


### PR DESCRIPTION
fixed bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Copy the default `SYSTEM_PROMPT_DICT` when constructing `system_msg` to prevent unintended mutations (e.g., duplicate tokens).
> 
> - **Evaluation utils**:
>   - In `llm_behavior_eval/evaluation_utils/custom_dataset.py`, `free_text_preprocess_function` now uses a shallow copy of `SYSTEM_PROMPT_DICT` when no `system_prompt` override is provided to avoid mutating the shared default system message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6620ae9f0c56faf4a7f601a6fec5b53372d48f6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->