### PR TITLE
LLM-61: Fix exception suppression in main evaluator

### DIFF
--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -488,9 +488,10 @@ def main(
         finally:
             if evaluator is not None:
                 evaluator.free_test_model()
-            else:
-                logging.error("Evaluator does not exist, see above for details")
-                return
+
+        if evaluator is None:
+            # Type-checking hint
+            raise ValueError("Evaluator does not exist.")
 
         # Grading loop
         with evaluator.get_grading_context() as judge:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents silent failure in the evaluation flow and clarifies error handling.
> 
> - Always call `evaluator.free_test_model()` if an evaluator was created; remove the branch that logged and returned early
> - After generation, explicitly `raise ValueError("Evaluator does not exist.")` if `evaluator` is `None`, ensuring the grading loop isn't entered without a valid evaluator
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 906813fd7792ea82568a0e2300021e7074a5581e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->