### PR TITLE
LLM-66: add pyright and testing pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
         entry: basedpyright
         language: system
         types: [python]
-        pass_filenames: false
+        pass_filenames: true
       - id: pytest
         name: pytest
         entry: pytest
         args: [-q]
         language: system
         types: [python]
-        pass_filenames: false
+        pass_filenames: true
         stages: [push]


### PR DESCRIPTION
Adds pytest and basedpyright to pre-commit hooks. 