### PR TITLE
LLM-81: Add Excel export for summary comparisons and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ Per‑model summaries are saved as `results/<model>/summary_full.csv` (full metr
 
 The metrics are composed of error (1 − accuracy), stereotype bias (when available) and the ratio of empty responses (i.e. the model generating empty string).
 
+### Export results to Excel
+
+Install Excel support with `uv pip install -e ".[excel]"` (included in the `dev` dependency group).
+
+You can export a comparison workbook with one sheet per dataset using:
+
+```bash
+llm-behavior-eval export-excel \
+  --reference-summary-csv /path/to/reference/summary_brief.csv \
+  --comparison-summary-csv /path/to/comparison/summary_brief.csv \
+  --output-file /path/to/comparison.xlsx
+```
+
+If `--dataset` is omitted, all overlapping datasets are exported. Optional `--dataset` can be passed multiple times to filter specific sheets, and model labels can be customized with `--reference-model-name` and `--comparison-model-name`.
+
 See the original papers for the explanation on accuracy. See the BBQ paper for the explanation of the stereotype bias.
 
 ## Tested on

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -23,6 +23,7 @@ from llm_behavior_eval.evaluation_utils.util_functions import (
 )
 from llm_behavior_eval.evaluation_utils.vllm_config import VllmConfig
 from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
+from llm_behavior_eval.export_excel import export_excel
 
 torch.set_float32_matmul_precision("high")
 
@@ -580,8 +581,67 @@ def main(
         empty_cuda_cache_if_available()
 
 
+def export_excel_command(
+    output_file: Annotated[
+        Path,
+        typer.Option(
+            "--output-file",
+            "-o",
+            help="Path to the .xlsx file to generate.",
+        ),
+    ],
+    reference_summary_csv: Annotated[
+        Path,
+        typer.Option(
+            "--reference-summary-csv",
+            help="Path to summary_brief.csv for the reference model.",
+        ),
+    ],
+    comparison_summary_csv: Annotated[
+        Path,
+        typer.Option(
+            "--comparison-summary-csv",
+            help="Path to summary_brief.csv for the comparison model.",
+        ),
+    ],
+    datasets: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--dataset",
+            help=(
+                "Dataset label from summary_brief.csv to include. "
+                "Provide multiple times for multiple sheets. Defaults to all."
+            ),
+        ),
+    ] = None,
+    reference_model_name: Annotated[
+        str,
+        typer.Option(
+            "--reference-model-name",
+            help="Display name for the reference model column in the workbook.",
+        ),
+    ] = "Pretrained model",
+    comparison_model_name: Annotated[
+        str,
+        typer.Option(
+            "--comparison-model-name",
+            help="Display name for the comparison model column in the workbook.",
+        ),
+    ] = "Unlearned model",
+) -> None:
+    export_excel(
+        output_file=output_file,
+        reference_summary_csv=reference_summary_csv,
+        comparison_summary_csv=comparison_summary_csv,
+        datasets=datasets,
+        reference_model_name=reference_model_name,
+        comparison_model_name=comparison_model_name,
+    )
+
+
 app = typer.Typer()
 app.command()(main)
+app.command("export-excel")(export_excel_command)
 
 if __name__ == "__main__":
     app()

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -26,6 +26,12 @@ from llm_behavior_eval.evaluation_utils.vllm_eval_engine import VllmEvalEngine
 from .custom_dataset import CustomDataset
 from .enums import DatasetType
 from .max_batch_size import MAX_BATCH_SIZE
+from .metrics import (
+    SUMMARY_ACCURACY_COLUMN,
+    SUMMARY_ATTACK_SUCCESS_COLUMN,
+    SUMMARY_DATASET_COLUMN,
+    SUMMARY_ERROR_COLUMN,
+)
 from .sampling_config import SamplingConfig
 from .util_functions import (
     config_to_dict,
@@ -374,13 +380,13 @@ class BaseEvaluator(ABC):
         # Prompt-injection grading stores model safety as accuracy, so attack success is 1 - accuracy.
         attack_success_rate = 1 - accuracy
         if is_purple_llama_injection:
-            metric_column_name = "Attack success rate (%) ⬇️"
+            metric_column_name = SUMMARY_ATTACK_SUCCESS_COLUMN
             metric_ratio_value = attack_success_rate
         elif is_unbias or is_hallucination:
-            metric_column_name = "Accuracy (%) ⬆️"
+            metric_column_name = SUMMARY_ACCURACY_COLUMN
             metric_ratio_value = accuracy
         else:
-            metric_column_name = "Error (%) ⬇️"
+            metric_column_name = SUMMARY_ERROR_COLUMN
             metric_ratio_value = attack_success_rate
         # Convert ratios to percentages
         metric_percentage_value = metric_ratio_value * 100.0
@@ -423,12 +429,12 @@ class BaseEvaluator(ABC):
         summary_row = pd.DataFrame(
             {
                 "Model": [model_slug],
-                "Dataset": [dataset_slug],
+                SUMMARY_DATASET_COLUMN: [dataset_slug],
                 "Dataset Type": [str(self.dataset_config.dataset_type)],
                 "Text Format": ["free_text"],
-                "Accuracy (%) ⬆️": [full_acc],
-                "Error (%) ⬇️": [full_err],
-                "Attack success rate (%) ⬇️": [full_attack_success_rate],
+                SUMMARY_ACCURACY_COLUMN: [full_acc],
+                SUMMARY_ERROR_COLUMN: [full_err],
+                SUMMARY_ATTACK_SUCCESS_COLUMN: [full_attack_success_rate],
                 "Stereotype Bias (%)": [stereo_percent],
                 "Empty Responses": [empty_responses],
             }
@@ -474,10 +480,10 @@ class BaseEvaluator(ABC):
         )
         brief_df = pd.DataFrame(
             {
-                "Dataset": [bias_label],
-                "Accuracy (%) ⬆️": [brief_acc],
-                "Error (%) ⬇️": [brief_err],
-                "Attack success rate (%) ⬇️": [brief_attack_success_rate],
+                SUMMARY_DATASET_COLUMN: [bias_label],
+                SUMMARY_ACCURACY_COLUMN: [brief_acc],
+                SUMMARY_ERROR_COLUMN: [brief_err],
+                SUMMARY_ATTACK_SUCCESS_COLUMN: [brief_attack_success_rate],
             }
         )
         brief_summary_path = model_results_dir / "summary_brief.csv"

--- a/llm_behavior_eval/evaluation_utils/metrics.py
+++ b/llm_behavior_eval/evaluation_utils/metrics.py
@@ -1,0 +1,4 @@
+SUMMARY_DATASET_COLUMN = "Dataset"
+SUMMARY_ACCURACY_COLUMN = "Accuracy (%) ⬆️"
+SUMMARY_ERROR_COLUMN = "Error (%) ⬇️"
+SUMMARY_ATTACK_SUCCESS_COLUMN = "Attack success rate (%) ⬇️"

--- a/llm_behavior_eval/export_excel.py
+++ b/llm_behavior_eval/export_excel.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, cast
+
+import pandas as pd
+
+from llm_behavior_eval.evaluation_utils.metrics import (
+    SUMMARY_ATTACK_SUCCESS_COLUMN,
+    SUMMARY_DATASET_COLUMN,
+    SUMMARY_ERROR_COLUMN,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SHEET_HEADER_BACKGROUND_COLOR = "#DCE6F1"
+CATEGORY_COLUMN_WIDTH = 24
+SCORE_COLUMN_WIDTH = 24
+
+
+def _sanitize_sheet_name(dataset_name: str) -> str:
+    invalid_sheet_characters = ["[", "]", ":", "*", "?", "/", "\\"]
+    sanitized_name = dataset_name
+    for invalid_character in invalid_sheet_characters:
+        sanitized_name = sanitized_name.replace(invalid_character, "-")
+    sanitized_name = sanitized_name.strip("'")
+    truncated_name = sanitized_name[:31] or "dataset"
+
+    if truncated_name != dataset_name:
+        logging.info(
+            "Adjusted sheet name from '%s' to '%s' to satisfy Excel constraints.",
+            dataset_name,
+            truncated_name,
+        )
+
+    return truncated_name
+
+
+def _normalize_metric_value(metric_name: str, metric_value: float) -> float:
+    if metric_name in {SUMMARY_ERROR_COLUMN, SUMMARY_ATTACK_SUCCESS_COLUMN}:
+        return 100.0 - metric_value
+    return metric_value
+
+
+def _load_summary(summary_path: Path, model_label: str) -> pd.DataFrame:
+    if not summary_path.exists():
+        raise FileNotFoundError(f"Summary file not found: {summary_path}")
+
+    summary_data = pd.read_csv(summary_path)
+    if SUMMARY_DATASET_COLUMN not in summary_data.columns:
+        raise ValueError(
+            f"Summary file {summary_path} is missing required column: {SUMMARY_DATASET_COLUMN}"
+        )
+
+    metric_columns = [
+        column_name
+        for column_name in summary_data.columns
+        if column_name != SUMMARY_DATASET_COLUMN
+    ]
+    if not metric_columns:
+        raise ValueError(
+            f"Summary file {summary_path} has no metric columns to export."
+        )
+
+    long_format_summary = summary_data.melt(
+        id_vars=[SUMMARY_DATASET_COLUMN],
+        value_vars=metric_columns,
+        var_name="Category",
+        value_name="RawMetricValue",
+    )
+    long_format_summary["RawMetricValue"] = pd.to_numeric(
+        long_format_summary["RawMetricValue"],
+        errors="coerce",
+    )
+    long_format_summary = long_format_summary.dropna(subset=["RawMetricValue"])
+    if long_format_summary.empty:
+        raise ValueError(
+            f"Summary file {summary_path} does not contain numeric metric values."
+        )
+
+    long_format_summary[model_label] = long_format_summary.apply(
+        lambda summary_row: _normalize_metric_value(
+            str(summary_row["Category"]),
+            float(summary_row["RawMetricValue"]),
+        ),
+        axis=1,
+    )
+
+    prepared_summary = long_format_summary.loc[
+        :,
+        [
+            SUMMARY_DATASET_COLUMN,
+            "Category",
+            model_label,
+        ],
+    ].reset_index(drop=True)
+    return cast("pd.DataFrame", prepared_summary)
+
+
+def export_excel(
+    output_file: Path,
+    reference_summary_csv: Path,
+    comparison_summary_csv: Path,
+    datasets: list[str] | None,
+    reference_model_name: str,
+    comparison_model_name: str,
+) -> None:
+    try:
+        import xlsxwriter.utility
+    except ImportError as import_error:
+        raise RuntimeError(
+            "Excel export requires optional dependency 'xlsxwriter'. "
+            "Install with: uv pip install -e '.[excel]'"
+        ) from import_error
+
+    reference_data = _load_summary(reference_summary_csv, reference_model_name)
+    comparison_data = _load_summary(comparison_summary_csv, comparison_model_name)
+
+    merged_comparison_data = reference_data.merge(
+        comparison_data,
+        on=[SUMMARY_DATASET_COLUMN, "Category"],
+        how="inner",
+    )
+    if merged_comparison_data.empty:
+        raise ValueError(
+            "No overlapping dataset/category values found between the reference and comparison summaries."
+        )
+
+    requested_datasets = set(datasets) if datasets else None
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with pd.ExcelWriter(output_file, engine="xlsxwriter") as excel_writer:
+        workbook = excel_writer.book
+
+        header_format = workbook.add_format(
+            {
+                "bold": True,
+                "bg_color": SHEET_HEADER_BACKGROUND_COLOR,
+                "border": 1,
+            }
+        )
+        score_format = workbook.add_format({"num_format": "0.000"})
+
+        for dataset_name, dataset_data in merged_comparison_data.groupby(
+            SUMMARY_DATASET_COLUMN,
+            sort=False,
+        ):
+            if requested_datasets and dataset_name not in requested_datasets:
+                continue
+
+            score_table = dataset_data[
+                ["Category", reference_model_name, comparison_model_name]
+            ].copy()
+
+            sheet_name = _sanitize_sheet_name(str(dataset_name))
+            score_table.to_excel(excel_writer, sheet_name=sheet_name, index=False)
+
+            worksheet = excel_writer.sheets[sheet_name]
+            for column_index, column_name in enumerate(score_table.columns):
+                worksheet.write(0, column_index, column_name, header_format)
+
+            worksheet.set_column(0, 0, CATEGORY_COLUMN_WIDTH)
+            worksheet.set_column(1, 2, SCORE_COLUMN_WIDTH, score_format)
+
+            category_row_count = len(score_table)
+            chart = workbook.add_chart({"type": "bar"})
+            category_range = f"='{sheet_name}'!$A$2:$A${category_row_count + 1}"
+
+            for series_column_index, series_name in [
+                (1, reference_model_name),
+                (2, comparison_model_name),
+            ]:
+                column_letter = xlsxwriter.utility.xl_col_to_name(series_column_index)
+                value_range = f"='{sheet_name}'!${column_letter}$2:${column_letter}${category_row_count + 1}"
+                chart.add_series(
+                    {
+                        "name": series_name,
+                        "categories": category_range,
+                        "values": value_range,
+                    }
+                )
+
+            chart.set_title({"name": f"{dataset_name} Comparison"})
+            chart.set_x_axis({"name": "Score (%)", "min": 0, "max": 100})
+            chart.set_y_axis({"name": "Category"})
+            chart.set_legend({"position": "bottom"})
+
+            worksheet.insert_chart("E2", chart)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+excel = [
+  "xlsxwriter>=3.2.0",
+]
 mlflow = [
   "mlflow>=2.0.0",
 ]
@@ -65,7 +68,7 @@ dev = [
   "basedpyright>=1.31.6",
   "pytest>=8.3.5",
   "pre-commit>=4.3.0",
-  "llm-behavior-eval[mlflow,vllm,gcs]",
+  "llm-behavior-eval[excel,mlflow,vllm,gcs]",
 ]
 docs = [
   "sphinx>=8.0.0",

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -458,3 +458,35 @@ def test_main_defaults_output_dir_to_data_dir(
     evaluate.main("fake/model", "hallu")
     eval_config = capture_eval_config[-1]
     assert eval_config.results_dir == expected
+
+
+def test_export_excel_command_passes_new_option_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_arguments: dict[str, object] = {}
+
+    def fake_export_excel(**keyword_arguments: object) -> None:
+        captured_arguments.update(keyword_arguments)
+
+    monkeypatch.setattr(evaluate, "export_excel", fake_export_excel)
+
+    evaluate.export_excel_command(
+        output_file=tmp_path / "comparison.xlsx",
+        reference_summary_csv=tmp_path / "reference_summary.csv",
+        comparison_summary_csv=tmp_path / "comparison_summary.csv",
+        datasets=["BBQ: gender bias"],
+        reference_model_name="Reference model",
+        comparison_model_name="Comparison model",
+    )
+
+    assert (
+        captured_arguments["reference_summary_csv"]
+        == tmp_path / "reference_summary.csv"
+    )
+    assert (
+        captured_arguments["comparison_summary_csv"]
+        == tmp_path / "comparison_summary.csv"
+    )
+    assert captured_arguments["reference_model_name"] == "Reference model"
+    assert captured_arguments["comparison_model_name"] == "Comparison model"

--- a/tests/test_export_excel.py
+++ b/tests/test_export_excel.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import zipfile
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+module_spec = importlib.util.spec_from_file_location(
+    "export_excel_module",
+    "llm_behavior_eval/export_excel.py",
+)
+assert module_spec is not None
+assert module_spec.loader is not None
+export_excel_module = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(export_excel_module)
+
+_sanitize_sheet_name = export_excel_module._sanitize_sheet_name
+export_excel = export_excel_module.export_excel
+
+
+def _write_summary(summary_path: Path, summary_dataframe: pd.DataFrame) -> None:
+    summary_dataframe.to_csv(summary_path, index=False)
+
+
+def test_sanitize_sheet_name_removes_invalid_characters_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO):
+        sanitized_name = _sanitize_sheet_name("BBQ: gender/bias?*")
+
+    assert sanitized_name == "BBQ- gender-bias--"
+    assert "Adjusted sheet name" in caplog.text
+
+
+def test_export_excel_writes_requested_datasets(tmp_path: Path) -> None:
+    reference_summary_path = tmp_path / "reference_summary_brief.csv"
+    comparison_summary_path = tmp_path / "comparison_summary_brief.csv"
+    output_file_path = tmp_path / "comparison.xlsx"
+
+    _write_summary(
+        reference_summary_path,
+        pd.DataFrame(
+            {
+                "Dataset": ["BBQ: gender bias", "UNQOVER: race bias"],
+                "Accuracy (%) ⬆️": [82.5, 74.1],
+                "Stereotype Bias (%)": [12.0, 18.5],
+            }
+        ),
+    )
+    _write_summary(
+        comparison_summary_path,
+        pd.DataFrame(
+            {
+                "Dataset": ["BBQ: gender bias", "UNQOVER: race bias"],
+                "Accuracy (%) ⬆️": [88.0, 79.0],
+                "Stereotype Bias (%)": [8.0, 15.0],
+            }
+        ),
+    )
+
+    export_excel(
+        output_file=output_file_path,
+        reference_summary_csv=reference_summary_path,
+        comparison_summary_csv=comparison_summary_path,
+        datasets=["BBQ: gender bias"],
+        reference_model_name="Pretrained model",
+        comparison_model_name="Unlearned model",
+    )
+
+    assert output_file_path.exists()
+
+    with zipfile.ZipFile(output_file_path, "r") as workbook_zip:
+        workbook_xml = workbook_zip.read("xl/workbook.xml").decode("utf-8")
+        sheet_xml = workbook_zip.read("xl/worksheets/sheet1.xml").decode("utf-8")
+
+    assert "BBQ- gender bias" in workbook_xml
+    assert "82.5" in sheet_xml
+    assert "88" in sheet_xml
+    assert "12" in sheet_xml
+    assert "8" in sheet_xml
+
+
+def test_export_excel_requires_overlap(tmp_path: Path) -> None:
+    reference_summary_path = tmp_path / "reference_summary_brief.csv"
+    comparison_summary_path = tmp_path / "comparison_summary_brief.csv"
+    output_file_path = tmp_path / "comparison.xlsx"
+
+    _write_summary(
+        reference_summary_path,
+        pd.DataFrame({"Dataset": ["BBQ: age bias"], "Accuracy (%) ⬆️": [70.0]}),
+    )
+    _write_summary(
+        comparison_summary_path,
+        pd.DataFrame(
+            {
+                "Dataset": ["UNQOVER: race bias"],
+                "Accuracy (%) ⬆️": [80.0],
+            }
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="No overlapping dataset/category values",
+    ):
+        export_excel(
+            output_file=output_file_path,
+            reference_summary_csv=reference_summary_path,
+            comparison_summary_csv=comparison_summary_path,
+            datasets=None,
+            reference_model_name="Pretrained model",
+            comparison_model_name="Unlearned model",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1617,6 +1617,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1627,6 +1628,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1637,6 +1639,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1647,6 +1650,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -2312,6 +2316,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+excel = [
+    { name = "xlsxwriter" },
+]
 gcs = [
     { name = "google-cloud-storage" },
 ]
@@ -2326,7 +2333,7 @@ vllm = [
 dev = [
     { name = "basedpyright" },
     { name = "bumpver" },
-    { name = "llm-behavior-eval", extra = ["gcs", "mlflow", "vllm"] },
+    { name = "llm-behavior-eval", extra = ["excel", "gcs", "mlflow", "vllm"] },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -2355,14 +2362,15 @@ requires-dist = [
     { name = "transformers", specifier = "<5.0.0" },
     { name = "typer", specifier = "<1.0.0" },
     { name = "vllm", marker = "extra == 'vllm'", specifier = ">=0.15.0" },
+    { name = "xlsxwriter", marker = "extra == 'excel'", specifier = ">=3.2.0" },
 ]
-provides-extras = ["mlflow", "vllm", "gcs"]
+provides-extras = ["excel", "mlflow", "vllm", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.31.6" },
     { name = "bumpver", specifier = ">=2024.1130" },
-    { name = "llm-behavior-eval", extras = ["mlflow", "vllm", "gcs"], editable = "." },
+    { name = "llm-behavior-eval", extras = ["excel", "mlflow", "vllm", "gcs"], editable = "." },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.11,<1.0.0" },
@@ -6178,6 +6186,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/ef/8a4b4cb10fc996c0a25c9bf5613aaf5a86114291a9a4003e43605cab42bf/xgrammar-0.1.29-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fedf21e447ef646f23a6e2d11877c0812d55965dcf8c0aa9b0f32590c9b6e22a", size = 17913609, upload-time = "2025-12-19T08:23:36.06Z" },
     { url = "https://files.pythonhosted.org/packages/e9/c5/e4965c9921e7bb6061f246ae7f8c7b9b1dfc21262248100c2f9b398b361e/xgrammar-0.1.29-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb22aea775971f7d8c4d0e193257ebeb71b68acd9d36af3331ca5fd4d9a46991", size = 34904126, upload-time = "2025-12-19T08:23:38.335Z" },
     { url = "https://files.pythonhosted.org/packages/09/26/641d7ee1a59e526aa94be980c485f899088d09dd1af517a2e1d0e85853bc/xgrammar-0.1.29-cp313-cp313-win_amd64.whl", hash = "sha256:12e6d63e892e9da8d088569dd629af58a5eafd909dc58788d499c4fd74bcd2a1", size = 5928450, upload-time = "2025-12-19T08:23:40.667Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# User description
### Motivation
- Provide a convenient way to export per-dataset comparison workbooks (one sheet per dataset) from summary CSVs for analysis and reporting.
- Make metric column names consistent across the codebase to avoid string duplication and reduce chance of typos.

### Description
- Added an `export_excel` utility (`llm_behavior_eval/export_excel.py`) that merges two `summary_brief.csv` files, normalizes metrics, writes an `.xlsx` workbook with one sheet per dataset, and inserts comparison charts; it uses `xlsxwriter` and validates input overlap and numeric values.
- Introduced metric name constants in `llm_behavior_eval/evaluation_utils/metrics.py` and updated `BaseEvaluator` to use these constants instead of hardcoded column header strings.
- Exposed the Excel export as a CLI command `export-excel` in `llm_behavior_eval/evaluate.py` via the `export_excel_command` wrapper and registered it on the `typer` app. 
- Documented the feature in `README.md` including usage example and install note to enable the optional `excel` dependency. 
- Added an optional dependency group `excel` with `xlsxwriter>=3.2.0` and included `excel` in the `dev` dependency group in `pyproject.toml`.
- Added tests: a new `tests/test_export_excel.py` suite validating sheet sanitization, file output, and overlap checking, and a CLI test in `tests/test_evaluate_cli.py` that checks the new command forwards options correctly.

### Testing
- Ran the test suite with `pytest` including the new `tests/test_export_excel.py` and modified `tests/test_evaluate_cli.py` tests, and they passed.
- Verified the new CLI unit test `test_export_excel_command_passes_new_option_names` passed and correctly exercises the `export_excel_command` argument mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a94aef1cd083319dd80099c3682f8d)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add Excel export as a CLI workflow via the new <code>export_excel</code> helper and register the <code>export-excel</code> command so teams can generate comparison workbooks directly from the <code>summary_brief.csv</code> outputs, complete with optional labels and dataset filtering along with docs and dependency updates to install <code>xlsxwriter</code>. Introduce metric column constants in <code>evaluation_utils.metrics</code> and consume them in <code>BaseEvaluator</code> so CSV generation stays consistent while also powering the Excel exporter.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/111?tool=ast&topic=Excel+export+flow>Excel export flow</a>
        </td><td>Implement Excel export workbook generation, CLI wiring, docs, dependency extras, and tests to let users compare pretrained/unlearned summaries via <code>export_excel</code> and <code>export-excel</code> commands with customizable labels and sheet selection.<details><summary>Modified files (7)</summary><ul><li>README.md</li>
<li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/export_excel.py</li>
<li>pyproject.toml</li>
<li>tests/test_evaluate_cli.py</li>
<li>tests/test_export_excel.py</li>
<li>uv.lock</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>LLM-75-Fix-Result-Dire...</td><td>March 01, 2026</td></tr>
<tr><td>mishana4life@gmail.com</td><td>LLM-64-Change-results-...</td><td>February 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/111?tool=ast&topic=Summary+metrics>Summary metrics</a>
        </td><td>Standardize summary metric headers by using <code>evaluation_utils.metrics</code> constants inside <code>BaseEvaluator</code> so generated CSVs remain aligned with the export tooling.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/metrics.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>LLM-76-Add-option-to-r...</td><td>March 02, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>LLM-68-Remove-empty-co...</td><td>February 19, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/111?tool=ast>(Baz)</a>.