### PR TITLE
LLM-92: Enable excluding thinking trace during judgement

### DIFF
--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -380,9 +380,16 @@ def main(
         str | None,
         typer.Option(
             "--thinking-end-token",
-            help="Thinking end token to use for the model (e.g. '</think>').",
+            help="Thinking end token to use for the model (e.g. '</think>'). Must be specified if `exclude_thinking_trace_for_judge=True`.",
         ),
     ] = None,
+    exclude_thinking_trace_for_judge: Annotated[
+        bool,
+        typer.Option(
+            "--exclude-thinking-trace-for-judge/--include-thinking-trace-for-judge",
+            help="Exclude thinking trace from judgement.",
+        ),
+    ] = False,
     max_samples: Annotated[
         int,
         typer.Option(
@@ -571,6 +578,7 @@ def main(
         enable_thinking_arg_name=enable_thinking_arg_name,
         thinking_start_token=thinking_start_token,
         thinking_end_token=thinking_end_token,
+        exclude_thinking_trace_for_judge=exclude_thinking_trace_for_judge,
         trust_remote_code=trust_remote_code
         if trust_remote_code is not None
         else model_path_or_repo_id.split("/")[0] in TRUSTED_MODEL_PROVIDERS,

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -986,6 +986,15 @@ class FreeTextSharedEvaluator(BaseEvaluator):
         )
         return existing_generations
 
+    def _format_answers(self, answers: list[str]) -> list[str]:
+        """
+        Format the answers to exclude the thinking trace if it is present.
+        """
+        if self.eval_config.thinking_end_token and self.eval_config.exclude_thinking_trace_for_judge:
+            return [answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip() for answer in answers]
+        else:
+            return answers
+
     def prepare_judge_tokenizer(self) -> None:
         """
         Load only the judge tokenizer so we can format probe prompts before

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -989,9 +989,21 @@ class FreeTextSharedEvaluator(BaseEvaluator):
     def _format_answers(self, answers: list[str]) -> list[str]:
         """
         Format the answers to exclude the thinking trace if it is present.
+
+        Args:
+            answers: List of answers to format.
+
+        Returns:
+            List of formatted answers.
         """
-        if self.eval_config.thinking_end_token and self.eval_config.exclude_thinking_trace_for_judge:
-            return [answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip() for answer in answers]
+        if (
+            self.eval_config.thinking_end_token
+            and self.eval_config.exclude_thinking_trace_for_judge
+        ):
+            return [
+                answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip()
+                for answer in answers
+            ]
         else:
             return answers
 

--- a/llm_behavior_eval/evaluation_utils/eval_config.py
+++ b/llm_behavior_eval/evaluation_utils/eval_config.py
@@ -145,7 +145,9 @@ class EvaluationConfig(BaseModel):
     @model_validator(mode="after")
     def validate_thinking_end_token(self):
         if self.exclude_thinking_trace_for_judge and not self.thinking_end_token:
-            raise ValueError("thinking_end_token must be specified in order to exclude thinking trace from judgement")
+            raise ValueError(
+                "thinking_end_token must be specified in order to exclude thinking trace from judgement"
+            )
         return self
 
 

--- a/llm_behavior_eval/evaluation_utils/eval_config.py
+++ b/llm_behavior_eval/evaluation_utils/eval_config.py
@@ -40,6 +40,7 @@ class EvaluationConfig(BaseModel):
         enable_thinking_arg_name: Enable thinking argument name in tokenizer's `apply_chat_template` (e.g. 'enable_thinking').
         thinking_start_token: Thinking start token to use for the model (e.g. '<think>').
         thinking_end_token: Thinking end token to use for the model (e.g. '</think>').
+        exclude_thinking_trace_for_judge: Whether to exclude thinking trace from judgement.
         trust_remote_code: Whether to trust remote code when loading models.
         sampling_config: Sampling configuration for model inference.
         mlflow_config: MLflow configuration for tracking (optional).
@@ -71,6 +72,7 @@ class EvaluationConfig(BaseModel):
     enable_thinking_arg_name: str | None = None
     thinking_start_token: str | None = None
     thinking_end_token: str | None = None
+    exclude_thinking_trace_for_judge: bool = False
     trust_remote_code: bool = False
     sampling_config: SamplingConfig = SamplingConfig()
     mlflow_config: "MlflowConfig | None" = None
@@ -138,6 +140,12 @@ class EvaluationConfig(BaseModel):
             raise ValueError(
                 "LoRA usage currently only supported with vLLM (Either inference_engine or model_engine must be set to 'vllm')"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_thinking_end_token(self):
+        if self.exclude_thinking_trace_for_judge and not self.thinking_end_token:
+            raise ValueError("thinking_end_token must be specified in order to exclude thinking trace from judgement")
         return self
 
 

--- a/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
@@ -351,6 +351,7 @@ candidate_uncertain: "<yes|no>"
             desc="Grading responses",
             unit="batch",
         ):
+            answers = self._format_answers(generation_record.answers)
             # categorize answers using the judge model
             with torch.inference_mode():
                 (
@@ -360,7 +361,7 @@ candidate_uncertain: "<yes|no>"
                     uncertainty_judge_raw,
                 ) = self._match_llm_answers(
                     judge_engine,
-                    generation_record.answers,
+                    answers,
                     generation_record.correct_answers,
                     generation_record.stereotyped_answers,
                     generation_record.questions,
@@ -382,7 +383,7 @@ candidate_uncertain: "<yes|no>"
                 judge_uncertainty,
             ) in zip(
                 generation_record.questions,
-                generation_record.answers,
+                answers,
                 generation_record.correct_answers,
                 stereo_iter,
                 agreements,

--- a/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
@@ -172,17 +172,18 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
+            answers = self._format_answers(generation.answers)
             with torch.inference_mode():
                 labels = self._grade_batch(
                     judge_engine,
                     generation.input_texts,
                     generation.gt_answers,
-                    generation.answers,
+                    answers,
                 )
             for question, gt_answer, generated_answer, label in zip(
                 generation.input_texts,
                 generation.gt_answers,
-                generation.answers,
+                answers,
                 labels,
                 strict=True,
             ):

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -185,8 +185,14 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            if self.eval_config.thinking_end_token and self.eval_config.exclude_thinking_trace_for_judge:
-                answers = [answer.split(self.eval_config.thinking_end_token)[-1].strip() for answer in generation.answers]
+            if (
+                self.eval_config.thinking_end_token
+                and self.eval_config.exclude_thinking_trace_for_judge
+            ):
+                answers = [
+                    answer.split(self.eval_config.thinking_end_token)[-1].strip()
+                    for answer in generation.answers
+                ]
             else:
                 answers = generation.answers
             with torch.inference_mode():

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -185,16 +185,7 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            if (
-                self.eval_config.thinking_end_token
-                and self.eval_config.exclude_thinking_trace_for_judge
-            ):
-                answers = [
-                    answer.split(self.eval_config.thinking_end_token)[-1].strip()
-                    for answer in generation.answers
-                ]
-            else:
-                answers = generation.answers
+            answers = self._format_answers(generation.answers)
             with torch.inference_mode():
                 labels = self._grade_batch(
                     judge_engine,

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -185,16 +185,20 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
+            if self.eval_config.thinking_end_token and self.eval_config.exclude_thinking_trace_for_judge:
+                answers = [answer.split(self.eval_config.thinking_end_token)[-1].strip() for answer in generation.answers]
+            else:
+                answers = generation.answers
             with torch.inference_mode():
                 labels = self._grade_batch(
                     judge_engine,
                     generation.judge_questions,
                     generation.gt_answers,
-                    generation.answers,
+                    answers,
                 )
             for question, llm_answer, label in zip(
                 generation.judge_questions,
-                generation.answers,
+                answers,
                 labels,
                 strict=True,
             ):


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable excluding thinking trace in <code>EvaluationConfig</code> by wiring a new CLI flag through <code>evaluate.main</code> so that <code>thinking_end_token</code> is required when trimming is requested. Format judge inputs and all free-text evaluators to strip sections before the thinking end token when the config flag is set so that judges score only final answers.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shmuli@hirundo.io</td><td>- updates from comment...</td><td>May 17, 2026</td></tr>
<tr><td>tomer@hirundo.io</td><td>updates from comments</td><td>May 06, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/119?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>