### PR TITLE
Revert "LLM-92: Enable excluding thinking trace during judgement"

### DIFF
--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -380,16 +380,9 @@ def main(
         str | None,
         typer.Option(
             "--thinking-end-token",
-            help="Thinking end token to use for the model (e.g. '</think>'). Must be specified if `exclude_thinking_trace_for_judge=True`.",
+            help="Thinking end token to use for the model (e.g. '</think>').",
         ),
     ] = None,
-    exclude_thinking_trace_for_judge: Annotated[
-        bool,
-        typer.Option(
-            "--exclude-thinking-trace-for-judge/--include-thinking-trace-for-judge",
-            help="Exclude thinking trace from judgement.",
-        ),
-    ] = False,
     max_samples: Annotated[
         int,
         typer.Option(
@@ -578,7 +571,6 @@ def main(
         enable_thinking_arg_name=enable_thinking_arg_name,
         thinking_start_token=thinking_start_token,
         thinking_end_token=thinking_end_token,
-        exclude_thinking_trace_for_judge=exclude_thinking_trace_for_judge,
         trust_remote_code=trust_remote_code
         if trust_remote_code is not None
         else model_path_or_repo_id.split("/")[0] in TRUSTED_MODEL_PROVIDERS,

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -986,27 +986,6 @@ class FreeTextSharedEvaluator(BaseEvaluator):
         )
         return existing_generations
 
-    def _format_answers(self, answers: list[str]) -> list[str]:
-        """
-        Format the answers to exclude the thinking trace if it is present.
-
-        Args:
-            answers: List of answers to format.
-
-        Returns:
-            List of formatted answers.
-        """
-        if (
-            self.eval_config.thinking_end_token
-            and self.eval_config.exclude_thinking_trace_for_judge
-        ):
-            return [
-                answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip()
-                for answer in answers
-            ]
-        else:
-            return answers
-
     def prepare_judge_tokenizer(self) -> None:
         """
         Load only the judge tokenizer so we can format probe prompts before

--- a/llm_behavior_eval/evaluation_utils/eval_config.py
+++ b/llm_behavior_eval/evaluation_utils/eval_config.py
@@ -40,7 +40,6 @@ class EvaluationConfig(BaseModel):
         enable_thinking_arg_name: Enable thinking argument name in tokenizer's `apply_chat_template` (e.g. 'enable_thinking').
         thinking_start_token: Thinking start token to use for the model (e.g. '<think>').
         thinking_end_token: Thinking end token to use for the model (e.g. '</think>').
-        exclude_thinking_trace_for_judge: Whether to exclude thinking trace from judgement.
         trust_remote_code: Whether to trust remote code when loading models.
         sampling_config: Sampling configuration for model inference.
         mlflow_config: MLflow configuration for tracking (optional).
@@ -72,7 +71,6 @@ class EvaluationConfig(BaseModel):
     enable_thinking_arg_name: str | None = None
     thinking_start_token: str | None = None
     thinking_end_token: str | None = None
-    exclude_thinking_trace_for_judge: bool = False
     trust_remote_code: bool = False
     sampling_config: SamplingConfig = SamplingConfig()
     mlflow_config: "MlflowConfig | None" = None
@@ -139,14 +137,6 @@ class EvaluationConfig(BaseModel):
         if self.lora_path_or_repo_id is not None and not using_vllm:
             raise ValueError(
                 "LoRA usage currently only supported with vLLM (Either inference_engine or model_engine must be set to 'vllm')"
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_thinking_end_token(self):
-        if self.exclude_thinking_trace_for_judge and not self.thinking_end_token:
-            raise ValueError(
-                "thinking_end_token must be specified in order to exclude thinking trace from judgement"
             )
         return self
 

--- a/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
@@ -351,7 +351,6 @@ candidate_uncertain: "<yes|no>"
             desc="Grading responses",
             unit="batch",
         ):
-            answers = self._format_answers(generation_record.answers)
             # categorize answers using the judge model
             with torch.inference_mode():
                 (
@@ -361,7 +360,7 @@ candidate_uncertain: "<yes|no>"
                     uncertainty_judge_raw,
                 ) = self._match_llm_answers(
                     judge_engine,
-                    answers,
+                    generation_record.answers,
                     generation_record.correct_answers,
                     generation_record.stereotyped_answers,
                     generation_record.questions,
@@ -383,7 +382,7 @@ candidate_uncertain: "<yes|no>"
                 judge_uncertainty,
             ) in zip(
                 generation_record.questions,
-                answers,
+                generation_record.answers,
                 generation_record.correct_answers,
                 stereo_iter,
                 agreements,

--- a/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
@@ -172,18 +172,17 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            answers = self._format_answers(generation.answers)
             with torch.inference_mode():
                 labels = self._grade_batch(
                     judge_engine,
                     generation.input_texts,
                     generation.gt_answers,
-                    answers,
+                    generation.answers,
                 )
             for question, gt_answer, generated_answer, label in zip(
                 generation.input_texts,
                 generation.gt_answers,
-                answers,
+                generation.answers,
                 labels,
                 strict=True,
             ):

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -185,17 +185,16 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            answers = self._format_answers(generation.answers)
             with torch.inference_mode():
                 labels = self._grade_batch(
                     judge_engine,
                     generation.judge_questions,
                     generation.gt_answers,
-                    answers,
+                    generation.answers,
                 )
             for question, llm_answer, label in zip(
                 generation.judge_questions,
-                answers,
+                generation.answers,
                 labels,
                 strict=True,
             ):


### PR DESCRIPTION
# User description
Reverts Hirundo-io/llm-behavior-eval#119

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Revert the thinking-trace exclusion by removing the <code>exclude_thinking_trace_for_judge</code> option from <code>main</code> and <code>EvaluationConfig</code>, ensuring the CLI entry point always tracks the full reasoning context. Confirm the free-text evaluators (<code>FreeTextBiasEvaluator</code>, <code>FreeTextHaluEvaluator</code>, and <code>FreeTextPromptInjectionEvaluator</code>) grade with the original <code>generation.answers</code> stream without intermediate formatting.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shmuelyo</td><td>Revert "LLM-92: Enable...</td><td>May 18, 2026</td></tr>
<tr><td>shmuli@hirundo.io</td><td>added thinking mode in...</td><td>May 17, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/122?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>