### PR TITLE
LLM-95: Fix bug in thinking trace exclusion for judge

### DIFF
--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -373,14 +373,20 @@ def main(
         str | None,
         typer.Option(
             "--thinking-start-token",
-            help="Thinking start token to use for the model (e.g. '<think>').",
+            help=(
+                "Thinking start token to use for the model (e.g. '<think>')."
+                "Must be specified when running with `--exclude-thinking-trace-for-judge`."
+            ),
         ),
     ] = None,
     thinking_end_token: Annotated[
         str | None,
         typer.Option(
             "--thinking-end-token",
-            help="Thinking end token to use for the model (e.g. '</think>'). Must be specified when running with `--exclude-thinking-trace-for-judge`.",
+            help=(
+                "Thinking end token to use for the model (e.g. '</think>'). "
+                "Must be specified when running with `--exclude-thinking-trace-for-judge`."
+            ),
         ),
     ] = None,
     exclude_thinking_trace_for_judge: Annotated[

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -1005,6 +1005,7 @@ class FreeTextSharedEvaluator(BaseEvaluator):
             return [
                 answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip()
                 if self.eval_config.thinking_start_token in answer
+                or self.eval_config.thinking_end_token in answer
                 else answer
                 for answer in answers
             ]

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -997,12 +997,15 @@ class FreeTextSharedEvaluator(BaseEvaluator):
             List of formatted answers.
         """
         if (
-            self.eval_config.thinking_end_token
+            self.eval_config.thinking_start_token
+            and self.eval_config.thinking_end_token
             and self.eval_config.exclude_thinking_trace_for_judge
         ):
             # NOTE This does not take into account the case where the thinking end token is in the body of the answer.
             return [
                 answer.rsplit(self.eval_config.thinking_end_token, 1)[-1].strip()
+                if self.eval_config.thinking_start_token in answer
+                else answer
                 for answer in answers
             ]
         else:

--- a/llm_behavior_eval/evaluation_utils/eval_config.py
+++ b/llm_behavior_eval/evaluation_utils/eval_config.py
@@ -144,7 +144,9 @@ class EvaluationConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_thinking_tokens(self):
-        if self.exclude_thinking_trace_for_judge and not (self.thinking_start_token and self.thinking_end_token):
+        if self.exclude_thinking_trace_for_judge and not (
+            self.thinking_start_token and self.thinking_end_token
+        ):
             raise ValueError(
                 "thinking_start_token and thinking_end_token must both be specified in order to exclude thinking trace from judgement"
             )

--- a/llm_behavior_eval/evaluation_utils/eval_config.py
+++ b/llm_behavior_eval/evaluation_utils/eval_config.py
@@ -143,10 +143,10 @@ class EvaluationConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_thinking_end_token(self):
-        if self.exclude_thinking_trace_for_judge and not self.thinking_end_token:
+    def validate_thinking_tokens(self):
+        if self.exclude_thinking_trace_for_judge and not (self.thinking_start_token and self.thinking_end_token):
             raise ValueError(
-                "thinking_end_token must be specified in order to exclude thinking trace from judgement"
+                "thinking_start_token and thinking_end_token must both be specified in order to exclude thinking trace from judgement"
             )
         return self
 

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -532,6 +532,7 @@ def test_format_answers_trims_thinking_trace_and_judge_prompt_uses_trimmed_text(
     evaluator.eval_config = EvaluationConfig(
         model_path_or_repo_id="meta/model",
         results_dir=tmp_path,
+        thinking_start_token="<think>",
         thinking_end_token="</think>",
         exclude_thinking_trace_for_judge=True,
     )
@@ -584,6 +585,7 @@ def test_format_answers_splits_on_last_thinking_end_token(
     evaluator.eval_config = EvaluationConfig(
         model_path_or_repo_id="meta/model",
         results_dir=tmp_path,
+        thinking_start_token="<think>",
         thinking_end_token="</think>",
         exclude_thinking_trace_for_judge=True,
     )


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the evaluation CLI help and <code>EvaluationConfig</code> validation to require both thinking tokens when <code>exclude_thinking_trace_for_judge</code> is set. Adjust <code>FreeTextSharedEvaluator</code> answer formatting (with tests) to skip trimming unless the thinking tokens appear, preventing judge text from being dropped when traces are absent.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/125?tool=ast&topic=Token+Requirement>Token Requirement</a>
        </td><td>Enforce <code>EvaluationConfig.validate_thinking_tokens</code> to require both <code>thinking_start_token</code> and <code>thinking_end_token</code> whenever <code>exclude_thinking_trace_for_judge</code> is enabled and clarify the CLI option help text.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/eval_config.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shmuli@hirundo.io</td><td>ruff fix</td><td>May 19, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-92: Enable excludi...</td><td>May 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/125?tool=ast&topic=Answer+Trimming>Answer Trimming</a>
        </td><td>Restrict <code>FreeTextSharedEvaluator._format_answers</code> to trim thinking traces only when either token appears and extend the formatter tests accordingly.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>tests/test_base_evaluator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shmuli@hirundo.io</td><td>updates from comments</td><td>May 19, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-92: Enable excludi...</td><td>May 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/125?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>