### PR TITLE
LLM-96: Update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 ## code changes will send PR to following users
-* @mishana @benglewis @shmuelyo @RotemHir @orr-hirundo
+* @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-dev
+#  ⬆️ Allow Admins and Developers to approve PRs with changes to the repository
+.github/workflows/ @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-devops
+uv.lock @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-devops
+#  ⬆️ Allow Admins and DevOps to approve PRs with changes just to GitHub Actions workflows and uv.lock


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update CODEOWNERS to assign admin and developer teams as approvers for general repository changes. Ensure GitHub workflow files and <code>uv.lock</code> rely on admins and DevOps team for approvals.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shmuli@hirundo.io</td><td>updated `CODEOWNERS`</td><td>May 20, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>LLM-60: Add missing `t...</td><td>January 13, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/127?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>