### PR TITLE
Add vLLM `fix_mistral_regex` option and CLI flag

### DIFF
--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -300,6 +300,13 @@ def main(
             help="Tokenizer mode forwarded to vLLM (e.g. 'auto', 'slow').",
         ),
     ] = None,
+    vllm_fix_mistral_regex: Annotated[
+        bool | None,
+        typer.Option(
+            "--vllm-fix-mistral-regex/--no-vllm-fix-mistral-regex",
+            help="Enable vLLM's compatibility fix for Mistral tokenizer regex parsing.",
+        ),
+    ] = None,
     vllm_config_format: Annotated[
         str | None,
         typer.Option(
@@ -559,6 +566,7 @@ def main(
             if vllm_judge_max_model_len is not None
             else vllm_max_model_len,
             tokenizer_mode=vllm_tokenizer_mode,
+            fix_mistral_regex=vllm_fix_mistral_regex,
             config_format=vllm_config_format,
             load_format=vllm_load_format,
             gpu_memory_utilization=vllm_gpu_memory_utilization,

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -405,7 +405,7 @@ def load_vllm_model(
     supports_fix_mistral_regex = "fix_mistral_regex" in llm_init_parameters
 
     with _hf_token(token):
-        llm_kwargs: dict[str, object] = {
+        llm_kwargs: dict[str, Any] = {
             "model": model_name,
             "trust_remote_code": trust_remote_code,
             "dtype": dtype_literal,

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -357,6 +357,7 @@ def load_vllm_model(
     quantization: QuantizationMethods | None = None,
     max_model_len: int | None = None,
     tokenizer_mode: TokenizerModeOption | None = None,
+    fix_mistral_regex: bool | None = None,
     config_format: str | None = None,
     load_format: str | None = None,
     gpu_memory_utilization: float = 0.9,
@@ -377,6 +378,7 @@ def load_vllm_model(
         quantization: Optional quantization backend (for example ``"bitsandbytes"`` for 4-bit inference).
         max_model_len: Optional maximum model length passed to vLLM.
         tokenizer_mode: Optional tokenizer mode string forwarded to vLLM.
+        fix_mistral_regex: Optional vLLM flag that enables Mistral regex compatibility.
         config_format: Optional config format string forwarded to vLLM.
         load_format: Optional checkpoint load format string forwarded to vLLM.
         gpu_memory_utilization: Optional GPU memory utilization passed to vLLM.
@@ -404,6 +406,7 @@ def load_vllm_model(
         tensor_parallel = gpu_count if gpu_count > 0 else None
 
     default_tokenizer_mode = _get_default_from_vllm("tokenizer_mode")
+    default_fix_mistral_regex = _get_default_from_vllm("fix_mistral_regex")
     default_tensor_parallel = _get_default_from_vllm("tensor_parallel_size")
 
     with _hf_token(token):
@@ -420,6 +423,11 @@ def load_vllm_model(
             hf_token=token,
             max_model_len=max_model_len,
             tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
+            fix_mistral_regex=(
+                fix_mistral_regex
+                if fix_mistral_regex is not None
+                else default_fix_mistral_regex
+            ),
             config_format=config_format,
             load_format=load_format,
             gpu_memory_utilization=gpu_memory_utilization,

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -7,7 +7,7 @@ import shutil
 from contextlib import contextmanager
 from inspect import signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import ParseResult, urlparse
 
 import torch
@@ -37,27 +37,6 @@ if TYPE_CHECKING:
 VLLMDType = Literal["bfloat16", "float16", "float32"]
 
 DIGEST_SIZE_FOR_PEFT_PATHS = 8
-
-
-class VllmInitKwargs(TypedDict, total=False):
-    model: str
-    trust_remote_code: bool
-    dtype: VLLMDType
-    enforce_eager: bool
-    quantization: "QuantizationMethods | None"
-    tensor_parallel_size: int
-    max_num_seqs: int
-    hf_token: str | None
-    max_model_len: int | None
-    tokenizer_mode: "TokenizerModeOption | str | None"
-    fix_mistral_regex: bool
-    config_format: str | None
-    load_format: str | None
-    gpu_memory_utilization: float
-    enable_lora: bool
-    max_lora_rank: int
-    language_model_only: bool
-    compilation_config: Any
 
 
 def empty_cuda_cache_if_available() -> None:
@@ -425,34 +404,40 @@ def load_vllm_model(
     default_tensor_parallel = llm_init_parameters["tensor_parallel_size"].default
     supports_fix_mistral_regex = "fix_mistral_regex" in llm_init_parameters
 
-    with _hf_token(token):
-        llm_kwargs: VllmInitKwargs = {
-            "model": model_name,
-            "trust_remote_code": trust_remote_code,
-            "dtype": dtype_literal,
-            "enforce_eager": enforce_eager,
-            "quantization": quantization,
-            "tensor_parallel_size": (
-                tensor_parallel
-                if tensor_parallel is not None
-                else default_tensor_parallel
-            ),
-            "max_num_seqs": batch_size,
-            "hf_token": token,
-            "max_model_len": max_model_len,
-            "tokenizer_mode": tokenizer_mode or default_tokenizer_mode,
-            "config_format": config_format,
-            "load_format": load_format,
-            "gpu_memory_utilization": gpu_memory_utilization,
-            "enable_lora": enable_lora,
-            "max_lora_rank": max_lora_rank,
-            "language_model_only": language_model_only,
-            "compilation_config": CompilationConfig(cudagraph_specialize_lora=False),
-        }
-        if supports_fix_mistral_regex and fix_mistral_regex is not None:
-            llm_kwargs["fix_mistral_regex"] = fix_mistral_regex
+    def _build_llm(fix_mistral_regex_value: bool | None = None) -> LLM:
+        llm_kwargs: dict[str, Any] = {}
+        if fix_mistral_regex_value is not None:
+            llm_kwargs["fix_mistral_regex"] = fix_mistral_regex_value
 
-        llm_instance = LLM(**llm_kwargs)
+        return LLM(
+            model=model_name,
+            trust_remote_code=trust_remote_code,
+            dtype=dtype_literal,
+            enforce_eager=enforce_eager,
+            quantization=quantization,
+            tensor_parallel_size=tensor_parallel
+            if tensor_parallel is not None
+            else default_tensor_parallel,
+            max_num_seqs=batch_size,
+            hf_token=token,
+            max_model_len=max_model_len,
+            tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
+            config_format=config_format,
+            load_format=load_format,
+            gpu_memory_utilization=gpu_memory_utilization,
+            enable_lora=enable_lora,
+            max_lora_rank=max_lora_rank,
+            language_model_only=language_model_only,
+            compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
+            **llm_kwargs,
+        )
+
+    with _hf_token(token):
+        llm_instance = _build_llm(
+            fix_mistral_regex
+            if supports_fix_mistral_regex and fix_mistral_regex is not None
+            else None
+        )
 
     return llm_instance
 

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -340,12 +340,6 @@ def torch_dtype_to_str(dtype: torch.dtype) -> VLLMDType:
     raise ValueError(f"Unsupported dtype for vLLM: {dtype}")
 
 
-def _get_default_from_vllm(parameter_name: str):
-    from vllm import LLM
-
-    return signature(LLM.__init__).parameters[parameter_name].default
-
-
 def load_vllm_model(
     model_name: str,
     dtype: torch.dtype,
@@ -405,37 +399,39 @@ def load_vllm_model(
         gpu_count = torch.cuda.device_count()
         tensor_parallel = gpu_count if gpu_count > 0 else None
 
-    default_tokenizer_mode = _get_default_from_vllm("tokenizer_mode")
-    default_fix_mistral_regex = _get_default_from_vllm("fix_mistral_regex")
-    default_tensor_parallel = _get_default_from_vllm("tensor_parallel_size")
+    llm_init_parameters = signature(LLM.__init__).parameters
+    default_tokenizer_mode = llm_init_parameters["tokenizer_mode"].default
+    default_tensor_parallel = llm_init_parameters["tensor_parallel_size"].default
+    supports_fix_mistral_regex = "fix_mistral_regex" in llm_init_parameters
 
     with _hf_token(token):
-        llm_instance = LLM(
-            model=model_name,
-            trust_remote_code=trust_remote_code,
-            dtype=dtype_literal,
-            enforce_eager=enforce_eager,
-            quantization=quantization,
-            tensor_parallel_size=tensor_parallel
-            if tensor_parallel is not None
-            else default_tensor_parallel,
-            max_num_seqs=batch_size,
-            hf_token=token,
-            max_model_len=max_model_len,
-            tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
-            fix_mistral_regex=(
-                fix_mistral_regex
-                if fix_mistral_regex is not None
-                else default_fix_mistral_regex
+        llm_kwargs: dict[str, object] = {
+            "model": model_name,
+            "trust_remote_code": trust_remote_code,
+            "dtype": dtype_literal,
+            "enforce_eager": enforce_eager,
+            "quantization": quantization,
+            "tensor_parallel_size": (
+                tensor_parallel
+                if tensor_parallel is not None
+                else default_tensor_parallel
             ),
-            config_format=config_format,
-            load_format=load_format,
-            gpu_memory_utilization=gpu_memory_utilization,
-            enable_lora=enable_lora,
-            max_lora_rank=max_lora_rank,
-            language_model_only=language_model_only,
-            compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
-        )
+            "max_num_seqs": batch_size,
+            "hf_token": token,
+            "max_model_len": max_model_len,
+            "tokenizer_mode": tokenizer_mode or default_tokenizer_mode,
+            "config_format": config_format,
+            "load_format": load_format,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "enable_lora": enable_lora,
+            "max_lora_rank": max_lora_rank,
+            "language_model_only": language_model_only,
+            "compilation_config": CompilationConfig(cudagraph_specialize_lora=False),
+        }
+        if supports_fix_mistral_regex and fix_mistral_regex is not None:
+            llm_kwargs["fix_mistral_regex"] = fix_mistral_regex
+
+        llm_instance = LLM(**llm_kwargs)
 
     return llm_instance
 

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -7,7 +7,7 @@ import shutil
 from contextlib import contextmanager
 from inspect import signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 from urllib.parse import ParseResult, urlparse
 
 import torch
@@ -37,6 +37,27 @@ if TYPE_CHECKING:
 VLLMDType = Literal["bfloat16", "float16", "float32"]
 
 DIGEST_SIZE_FOR_PEFT_PATHS = 8
+
+
+class VllmInitKwargs(TypedDict, total=False):
+    model: str
+    trust_remote_code: bool
+    dtype: VLLMDType
+    enforce_eager: bool
+    quantization: "QuantizationMethods | None"
+    tensor_parallel_size: int
+    max_num_seqs: int
+    hf_token: str | None
+    max_model_len: int | None
+    tokenizer_mode: "TokenizerModeOption | str | None"
+    fix_mistral_regex: bool
+    config_format: str | None
+    load_format: str | None
+    gpu_memory_utilization: float
+    enable_lora: bool
+    max_lora_rank: int
+    language_model_only: bool
+    compilation_config: Any
 
 
 def empty_cuda_cache_if_available() -> None:
@@ -405,51 +426,33 @@ def load_vllm_model(
     supports_fix_mistral_regex = "fix_mistral_regex" in llm_init_parameters
 
     with _hf_token(token):
+        llm_kwargs: VllmInitKwargs = {
+            "model": model_name,
+            "trust_remote_code": trust_remote_code,
+            "dtype": dtype_literal,
+            "enforce_eager": enforce_eager,
+            "quantization": quantization,
+            "tensor_parallel_size": (
+                tensor_parallel
+                if tensor_parallel is not None
+                else default_tensor_parallel
+            ),
+            "max_num_seqs": batch_size,
+            "hf_token": token,
+            "max_model_len": max_model_len,
+            "tokenizer_mode": tokenizer_mode or default_tokenizer_mode,
+            "config_format": config_format,
+            "load_format": load_format,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "enable_lora": enable_lora,
+            "max_lora_rank": max_lora_rank,
+            "language_model_only": language_model_only,
+            "compilation_config": CompilationConfig(cudagraph_specialize_lora=False),
+        }
         if supports_fix_mistral_regex and fix_mistral_regex is not None:
-            llm_instance = LLM(
-                model=model_name,
-                trust_remote_code=trust_remote_code,
-                dtype=dtype_literal,
-                enforce_eager=enforce_eager,
-                quantization=quantization,
-                tensor_parallel_size=tensor_parallel
-                if tensor_parallel is not None
-                else default_tensor_parallel,
-                max_num_seqs=batch_size,
-                hf_token=token,
-                max_model_len=max_model_len,
-                tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
-                fix_mistral_regex=fix_mistral_regex,
-                config_format=config_format,
-                load_format=load_format,
-                gpu_memory_utilization=gpu_memory_utilization,
-                enable_lora=enable_lora,
-                max_lora_rank=max_lora_rank,
-                language_model_only=language_model_only,
-                compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
-            )
-        else:
-            llm_instance = LLM(
-                model=model_name,
-                trust_remote_code=trust_remote_code,
-                dtype=dtype_literal,
-                enforce_eager=enforce_eager,
-                quantization=quantization,
-                tensor_parallel_size=tensor_parallel
-                if tensor_parallel is not None
-                else default_tensor_parallel,
-                max_num_seqs=batch_size,
-                hf_token=token,
-                max_model_len=max_model_len,
-                tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
-                config_format=config_format,
-                load_format=load_format,
-                gpu_memory_utilization=gpu_memory_utilization,
-                enable_lora=enable_lora,
-                max_lora_rank=max_lora_rank,
-                language_model_only=language_model_only,
-                compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
-            )
+            llm_kwargs["fix_mistral_regex"] = fix_mistral_regex
+
+        llm_instance = LLM(**llm_kwargs)
 
     return llm_instance
 

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -405,33 +405,51 @@ def load_vllm_model(
     supports_fix_mistral_regex = "fix_mistral_regex" in llm_init_parameters
 
     with _hf_token(token):
-        llm_kwargs: dict[str, Any] = {
-            "model": model_name,
-            "trust_remote_code": trust_remote_code,
-            "dtype": dtype_literal,
-            "enforce_eager": enforce_eager,
-            "quantization": quantization,
-            "tensor_parallel_size": (
-                tensor_parallel
-                if tensor_parallel is not None
-                else default_tensor_parallel
-            ),
-            "max_num_seqs": batch_size,
-            "hf_token": token,
-            "max_model_len": max_model_len,
-            "tokenizer_mode": tokenizer_mode or default_tokenizer_mode,
-            "config_format": config_format,
-            "load_format": load_format,
-            "gpu_memory_utilization": gpu_memory_utilization,
-            "enable_lora": enable_lora,
-            "max_lora_rank": max_lora_rank,
-            "language_model_only": language_model_only,
-            "compilation_config": CompilationConfig(cudagraph_specialize_lora=False),
-        }
         if supports_fix_mistral_regex and fix_mistral_regex is not None:
-            llm_kwargs["fix_mistral_regex"] = fix_mistral_regex
-
-        llm_instance = LLM(**llm_kwargs)
+            llm_instance = LLM(
+                model=model_name,
+                trust_remote_code=trust_remote_code,
+                dtype=dtype_literal,
+                enforce_eager=enforce_eager,
+                quantization=quantization,
+                tensor_parallel_size=tensor_parallel
+                if tensor_parallel is not None
+                else default_tensor_parallel,
+                max_num_seqs=batch_size,
+                hf_token=token,
+                max_model_len=max_model_len,
+                tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
+                fix_mistral_regex=fix_mistral_regex,
+                config_format=config_format,
+                load_format=load_format,
+                gpu_memory_utilization=gpu_memory_utilization,
+                enable_lora=enable_lora,
+                max_lora_rank=max_lora_rank,
+                language_model_only=language_model_only,
+                compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
+            )
+        else:
+            llm_instance = LLM(
+                model=model_name,
+                trust_remote_code=trust_remote_code,
+                dtype=dtype_literal,
+                enforce_eager=enforce_eager,
+                quantization=quantization,
+                tensor_parallel_size=tensor_parallel
+                if tensor_parallel is not None
+                else default_tensor_parallel,
+                max_num_seqs=batch_size,
+                hf_token=token,
+                max_model_len=max_model_len,
+                tokenizer_mode=tokenizer_mode or default_tokenizer_mode,
+                config_format=config_format,
+                load_format=load_format,
+                gpu_memory_utilization=gpu_memory_utilization,
+                enable_lora=enable_lora,
+                max_lora_rank=max_lora_rank,
+                language_model_only=language_model_only,
+                compilation_config=CompilationConfig(cudagraph_specialize_lora=False),
+            )
 
     return llm_instance
 

--- a/llm_behavior_eval/evaluation_utils/vllm_config.py
+++ b/llm_behavior_eval/evaluation_utils/vllm_config.py
@@ -17,6 +17,7 @@ class VllmConfig(BaseModel):
         judge_max_model_len: Maximum model length for vLLM judge inference (optional).
             Defaults to the same value as max_model_len if not specified.
         tokenizer_mode: Tokenizer mode forwarded to vLLM (e.g. 'auto', 'slow', 'mistral', 'custom').
+        fix_mistral_regex: Whether to enable vLLM's Mistral regex compatibility fix.
         config_format: Model config format hint forwarded to vLLM (optional).
         load_format: Checkpoint load format hint forwarded to vLLM (optional).
         enable_lora: Whether to enable LoRA.
@@ -28,6 +29,7 @@ class VllmConfig(BaseModel):
     max_model_len: int | None = None
     judge_max_model_len: int | None = None
     tokenizer_mode: TokenizerModeOption | None = None
+    fix_mistral_regex: bool | None = None
     config_format: str | None = None
     load_format: str | None = None
     gpu_memory_utilization: float = 0.9

--- a/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
+++ b/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
@@ -75,6 +75,7 @@ class VllmEvalEngine(EvalEngine):
             quantization=quantization,
             max_model_len=max_model_len,
             tokenizer_mode=vllm_config.tokenizer_mode,
+            fix_mistral_regex=vllm_config.fix_mistral_regex,
             config_format=vllm_config.config_format,
             load_format=vllm_config.load_format,
             gpu_memory_utilization=vllm_config.gpu_memory_utilization,

--- a/tests/test_eval_engines.py
+++ b/tests/test_eval_engines.py
@@ -359,6 +359,7 @@ def test_vllm_eval_engine_passes_optional_kwargs(vllm_bundle, tmp_path) -> None:
 
     vllm_config = VllmConfig(
         tokenizer_mode="slow",
+        fix_mistral_regex=True,
         config_format="hf-torch",
         load_format="dummy",
     )
@@ -373,6 +374,7 @@ def test_vllm_eval_engine_passes_optional_kwargs(vllm_bundle, tmp_path) -> None:
 
     last_call = vllm_bundle.model_loader.calls[-1]["kwargs"]
     assert last_call["tokenizer_mode"] == "slow"
+    assert last_call["fix_mistral_regex"] is True
     assert last_call["config_format"] == "hf-torch"
     assert last_call["load_format"] == "dummy"
 

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -188,12 +188,14 @@ def test_main_passes_vllm_optional_args(
         "hallu",
         inference_engine="vllm",
         vllm_tokenizer_mode="slow",
+        vllm_fix_mistral_regex=True,
         vllm_config_format="hf",
         vllm_load_format="safetensors",
     )
     eval_config = capture_eval_config[-1]
     assert eval_config.vllm_config is not None
     assert eval_config.vllm_config.tokenizer_mode == "slow"
+    assert eval_config.vllm_config.fix_mistral_regex is True
     assert eval_config.vllm_config.config_format == "hf"
     assert eval_config.vllm_config.load_format == "safetensors"
 


### PR DESCRIPTION
# User description
### Motivation
- Provide an explicit configuration toggle so vLLM can apply the Mistral tokenizer regex compatibility fix for Mistral-family models, preventing prompt parsing issues.
- Surface the option through the CLI so users can enable/disable the behavior for runs without editing code.

### Description
- Add `fix_mistral_regex: bool | None` to `VllmConfig` to represent the vLLM tokenizer regex compatibility flag.
- Extend `load_vllm_model` to accept `fix_mistral_regex` and query vLLM's default via `_get_default_from_vllm` when the value is not provided, then pass the resolved value into `vllm.LLM(...)`.
- Wire a new CLI option `--vllm-fix-mistral-regex/--no-vllm-fix-mistral-regex` into `evaluate.main` and propagate the value into the constructed `VllmConfig`.
- Forward the `fix_mistral_regex` value from `VllmConfig` in `VllmEvalEngine` when calling `load_vllm_model` and add assertions in relevant tests to validate propagation.

### Testing
- Ran `pytest tests/test_evaluate_cli.py -k vllm_optional_args` which failed during collection due to a missing environment dependency (`ModuleNotFoundError: No module named 'pydantic_settings'`).
- The subsequent `pytest tests/test_eval_engines.py -k passes_optional_kwargs` was not executed because collection failed in the previous step; test files were updated to assert the new flag is propagated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0eae3da3488320b5fd689a56091aba)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a CLI option and config field to control vLLM's Mistral regex fix so <code>evaluate.main</code>, <code>VllmConfig</code>, and <code>VllmEvalEngine</code> pass the flag down to <code>load_vllm_model</code>. Ensure <code>load_vllm_model</code> inspects <code>vllm.LLM</code> parameters for defaults and relays the resolved value while the new tests assert propagation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/128?tool=ast&topic=Default+detection>Default detection</a>
        </td><td>Handle default <code>fix_mistral_regex</code> behavior by inspecting <code>vllm.LLM</code> constructor parameters, only forwarding the flag when supported, and simplifying the helper logic.<details><summary>Modified files (1)</summary><ul><li>llm_behavior_eval/evaluation_utils/util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>eliran@hirundo.io</td><td>Avoid pyright kwargs u...</td><td>May 21, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-70: Add support fo...</td><td>May 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/128?tool=ast&topic=Fix+flag+propagation>Fix flag propagation</a>
        </td><td>Propagate <code>vllm_fix_mistral_regex</code> from the CLI through <code>VllmConfig</code> and <code>VllmEvalEngine</code> so <code>load_vllm_model</code> receives the user’s toggle and the tests confirm it.<details><summary>Modified files (5)</summary><ul><li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/vllm_config.py</li>
<li>llm_behavior_eval/evaluation_utils/vllm_eval_engine.py</li>
<li>tests/test_eval_engines.py</li>
<li>tests/test_evaluate_cli.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>eliran@hirundo.io</td><td>Add fix_mistral_regex ...</td><td>May 21, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-93: Add finish rea...</td><td>May 20, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/128?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>