### PR TITLE
LLM-99: Infer MLflow run and metric step from LoRA adapter refs

### DIFF
--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -721,7 +721,7 @@ class BaseEvaluator(ABC):
         # Generate run name if not specified
         model_slug = self.get_model_slug()
 
-        requested_run_id = self.mlflow_config.mlflow_run_id
+        requested_run_id = self.mlflow_config.mlflow_run_id or self._lora_mlflow_run_id
         active_run = mlflow.active_run()
 
         if requested_run_id:
@@ -792,10 +792,7 @@ class BaseEvaluator(ABC):
         """Log evaluation metrics to MLflow."""
         if not self.eval_config.mlflow_config or not mlflow:
             return
-        if self._inferred_mlflow_metric_step is not None:
-            mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
-            return
-        mlflow.log_metrics(metrics)
+        mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
 
     def _resolve_mlflow_metric_step(self, inferred_step: int | None) -> int | None:
         """Use inferred checkpoint step only when logging back to same MLflow run."""

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -695,6 +695,22 @@ class BaseEvaluator(ABC):
     def should_include_dataset_type_in_output_dir(self) -> bool:
         return False
 
+    def _attach_existing_mlflow_run(self, run_id: str, description: str) -> None:
+        """Attach an existing MLflow run to the current run.
+
+        Args:
+            run_id: The ID of the existing MLflow run to attach.
+            description: A description of the run to attach.
+        """
+        if not mlflow:
+            return
+        existing = mlflow.get_run(run_id)
+        mlflow.set_experiment(experiment_id=existing.info.experiment_id)
+        mlflow.start_run(run_id=run_id)
+        self.parent_run = self.mlflow_run = mlflow.active_run()
+        self._started_mlflow_run = True
+        logging.info(f"Attached existing MLflow run: {run_id} ({description})")
+
     def _init_mlflow(self) -> None:
         """Initialize MLflow tracking if enabled and available."""
         if not mlflow:
@@ -758,22 +774,6 @@ class BaseEvaluator(ABC):
         )
 
         # Run config is uploaded as JSON in artifacts (e.g. run_config.json), not logged as params/metrics.
-
-    def _attach_existing_mlflow_run(self, run_id: str, description: str) -> None:
-        """Attach an existing MLflow run to the current run.
-
-        Args:
-            run_id: The ID of the existing MLflow run to attach.
-            description: A description of the run to attach.
-        """
-        if not mlflow:
-            return
-        existing = mlflow.get_run(run_id)
-        mlflow.set_experiment(experiment_id=existing.info.experiment_id)
-        mlflow.start_run(run_id=run_id)
-        self.parent_run = self.mlflow_run = mlflow.active_run()
-        self._started_mlflow_run = True
-        logging.info(f"Attached existing MLflow run: {run_id} ({description})")
 
     @contextmanager
     def dataset_mlflow_run(self) -> Generator[None, None, None]:

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -31,6 +31,7 @@ from .max_batch_size import MAX_BATCH_SIZE
 from .sampling_config import SamplingConfig
 from .util_functions import (
     empty_cuda_cache_if_available,
+    extract_mlflow_run_id_from_adapter_ref,
     get_lora_slug,
     infer_mlflow_metric_step_from_lora_path,
     load_tokenizer_with_transformers,
@@ -122,17 +123,25 @@ class BaseEvaluator(ABC):
         self.mlflow_run = None
         self.parent_run = None
         self._started_mlflow_run = False
-        self._inferred_mlflow_metric_step = infer_mlflow_metric_step_from_lora_path(
+        self._inferred_mlflow_metric_step: int | None = None
+        inferred_step = infer_mlflow_metric_step_from_lora_path(
             self.eval_config.lora_path_or_repo_id
         )
-        if self._inferred_mlflow_metric_step is not None:
+        if inferred_step is not None:
             logging.info(
                 "Inferred MLflow metric step %s from LoRA checkpoint path %s",
-                self._inferred_mlflow_metric_step,
+                inferred_step,
                 self.eval_config.lora_path_or_repo_id,
             )
+        self._lora_mlflow_run_id = extract_mlflow_run_id_from_adapter_ref(
+            self.eval_config.lora_path_or_repo_id,
+            self.mlflow_config.mlflow_tracking_uri if self.mlflow_config else None,
+        )
         if self.mlflow_config:
             self._init_mlflow()
+            self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
+                inferred_step
+            )
 
         self.data_collator = default_data_collator
         if self.model_engine == "vllm":
@@ -787,6 +796,23 @@ class BaseEvaluator(ABC):
             mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
             return
         mlflow.log_metrics(metrics)
+
+    def _resolve_mlflow_metric_step(self, inferred_step: int | None) -> int | None:
+        """Use inferred checkpoint step only when logging back to same MLflow run."""
+        if inferred_step is None:
+            return None
+        if self._lora_mlflow_run_id is None:
+            return None
+        current_run_id = self.parent_run.info.run_id if self.parent_run else None
+        if current_run_id == self._lora_mlflow_run_id:
+            return inferred_step
+        logging.info(
+            "Skipping inferred MLflow metric step %s: LoRA run %s differs from logging run %s",
+            inferred_step,
+            self._lora_mlflow_run_id,
+            current_run_id,
+        )
+        return None
 
     def _sanitize_mlflow_key(self, name: str) -> str:
         """Return a key safe for MLflow params/metrics: alphanumeric and underscores only.

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -32,6 +32,7 @@ from .sampling_config import SamplingConfig
 from .util_functions import (
     empty_cuda_cache_if_available,
     get_lora_slug,
+    infer_mlflow_metric_step_from_lora_path,
     load_tokenizer_with_transformers,
 )
 
@@ -121,6 +122,15 @@ class BaseEvaluator(ABC):
         self.mlflow_run = None
         self.parent_run = None
         self._started_mlflow_run = False
+        self._inferred_mlflow_metric_step = infer_mlflow_metric_step_from_lora_path(
+            self.eval_config.lora_path_or_repo_id
+        )
+        if self._inferred_mlflow_metric_step is not None:
+            logging.info(
+                "Inferred MLflow metric step %s from LoRA checkpoint path %s",
+                self._inferred_mlflow_metric_step,
+                self.eval_config.lora_path_or_repo_id,
+            )
         if self.mlflow_config:
             self._init_mlflow()
 
@@ -772,6 +782,9 @@ class BaseEvaluator(ABC):
     def _log_mlflow_metrics(self, metrics: dict[str, Any]) -> None:
         """Log evaluation metrics to MLflow."""
         if not self.eval_config.mlflow_config or not mlflow:
+            return
+        if self._inferred_mlflow_metric_step is not None:
+            mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
             return
         mlflow.log_metrics(metrics)
 

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -721,7 +721,7 @@ class BaseEvaluator(ABC):
         # Generate run name if not specified
         model_slug = self.get_model_slug()
 
-        requested_run_id = self.mlflow_config.mlflow_run_id or self._lora_mlflow_run_id
+        requested_run_id = self.mlflow_config.mlflow_run_id
         active_run = mlflow.active_run()
 
         if requested_run_id:
@@ -745,6 +745,16 @@ class BaseEvaluator(ABC):
             logging.warning(
                 "Using existing active run %s as main run",
                 active_run.info.run_id,
+            )
+        elif self._lora_mlflow_run_id:
+            existing = mlflow.get_run(self._lora_mlflow_run_id)
+            mlflow.set_experiment(experiment_id=existing.info.experiment_id)
+            mlflow.start_run(run_id=self._lora_mlflow_run_id)
+            self.parent_run = self.mlflow_run = mlflow.active_run()
+            self._started_mlflow_run = True
+            logging.info(
+                "Logging to MLflow run inferred from LoRA adapter: %s",
+                self._lora_mlflow_run_id,
             )
         else:
             run_name = self.mlflow_config.mlflow_run_name or f"{model_slug}"

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -742,7 +742,9 @@ class BaseEvaluator(ABC):
                 active_run.info.run_id,
             )
         elif self._lora_mlflow_run_id:
-            self._attach_existing_mlflow_run(self._lora_mlflow_run_id, "Run inferred from LoRA adapter")
+            self._attach_existing_mlflow_run(
+                self._lora_mlflow_run_id, "Run inferred from LoRA adapter"
+            )
         else:
             run_name = self.mlflow_config.mlflow_run_name or f"{model_slug}"
             self.mlflow_run = mlflow.start_run(run_name=run_name)
@@ -758,7 +760,12 @@ class BaseEvaluator(ABC):
         # Run config is uploaded as JSON in artifacts (e.g. run_config.json), not logged as params/metrics.
 
     def _attach_existing_mlflow_run(self, run_id: str, description: str) -> None:
-        """Attach an existing MLflow run to the current run."""
+        """Attach an existing MLflow run to the current run.
+
+        Args:
+            run_id: The ID of the existing MLflow run to attach.
+            description: A description of the run to attach.
+        """
         if not mlflow:
             return
         existing = mlflow.get_run(run_id)

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -127,21 +127,21 @@ class BaseEvaluator(ABC):
         inferred_step = infer_mlflow_metric_step_from_lora_path(
             self.eval_config.lora_path_or_repo_id
         )
-        if inferred_step is not None:
-            logging.info(
-                "Inferred MLflow metric step %s from LoRA checkpoint path %s",
-                inferred_step,
-                self.eval_config.lora_path_or_repo_id,
-            )
         self._lora_mlflow_run_id = extract_mlflow_run_id_from_adapter_ref(
             self.eval_config.lora_path_or_repo_id,
             self.mlflow_config.mlflow_tracking_uri if self.mlflow_config else None,
         )
         if self.mlflow_config:
             self._init_mlflow()
-            self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
-                inferred_step
-            )
+            if inferred_step is not None:
+                logging.info(
+                    "Inferred MLflow metric step %s from LoRA checkpoint path %s",
+                    inferred_step,
+                    self.eval_config.lora_path_or_repo_id,
+                )
+                self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
+                    inferred_step
+                )
 
         self.data_collator = default_data_collator
         if self.model_engine == "vllm":
@@ -733,12 +733,7 @@ class BaseEvaluator(ABC):
                     requested_run_id,
                 )
             else:
-                existing = mlflow.get_run(requested_run_id)
-                mlflow.set_experiment(experiment_id=existing.info.experiment_id)
-                mlflow.start_run(run_id=requested_run_id)
-                self.parent_run = self.mlflow_run = mlflow.active_run()
-                self._started_mlflow_run = True
-                logging.info("Logging to existing MLflow run: %s", requested_run_id)
+                self._attach_existing_mlflow_run(requested_run_id, "Requested run ID")
         elif active_run is not None:
             self.parent_run = self.mlflow_run = active_run
             self._started_mlflow_run = False
@@ -747,15 +742,7 @@ class BaseEvaluator(ABC):
                 active_run.info.run_id,
             )
         elif self._lora_mlflow_run_id:
-            existing = mlflow.get_run(self._lora_mlflow_run_id)
-            mlflow.set_experiment(experiment_id=existing.info.experiment_id)
-            mlflow.start_run(run_id=self._lora_mlflow_run_id)
-            self.parent_run = self.mlflow_run = mlflow.active_run()
-            self._started_mlflow_run = True
-            logging.info(
-                "Logging to MLflow run inferred from LoRA adapter: %s",
-                self._lora_mlflow_run_id,
-            )
+            self._attach_existing_mlflow_run(self._lora_mlflow_run_id, "Run inferred from LoRA adapter")
         else:
             run_name = self.mlflow_config.mlflow_run_name or f"{model_slug}"
             self.mlflow_run = mlflow.start_run(run_name=run_name)
@@ -769,6 +756,17 @@ class BaseEvaluator(ABC):
         )
 
         # Run config is uploaded as JSON in artifacts (e.g. run_config.json), not logged as params/metrics.
+
+    def _attach_existing_mlflow_run(self, run_id: str, description: str) -> None:
+        """Attach an existing MLflow run to the current run."""
+        if not mlflow:
+            return
+        existing = mlflow.get_run(run_id)
+        mlflow.set_experiment(experiment_id=existing.info.experiment_id)
+        mlflow.start_run(run_id=run_id)
+        self.parent_run = self.mlflow_run = mlflow.active_run()
+        self._started_mlflow_run = True
+        logging.info(f"Attached existing MLflow run: {run_id} ({description})")
 
     @contextmanager
     def dataset_mlflow_run(self) -> Generator[None, None, None]:
@@ -805,7 +803,6 @@ class BaseEvaluator(ABC):
         mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
 
     def _resolve_mlflow_metric_step(self, inferred_step: int | None) -> int | None:
-        """Use inferred checkpoint step only when logging back to same MLflow run."""
         if inferred_step is None:
             return None
         if self._lora_mlflow_run_id is None:
@@ -813,7 +810,7 @@ class BaseEvaluator(ABC):
         current_run_id = self.parent_run.info.run_id if self.parent_run else None
         if current_run_id == self._lora_mlflow_run_id:
             return inferred_step
-        logging.info(
+        logging.debug(
             "Skipping inferred MLflow metric step %s: LoRA run %s differs from logging run %s",
             inferred_step,
             self._lora_mlflow_run_id,

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -540,7 +540,8 @@ def parse_mlflow_adapter_url(
 
     Supported forms:
       - ``mlflow://<run_id>`` and ``mlflow://<run_id>/<artifact/path>``
-      - ``runs:/<run_id>`` and ``runs:/<run_id>/<artifact/path>``
+      - ``runs:/<run_id>`` and ``runs:/<run_id>/<artifact/path>`` (MLflow artifact URI;
+        ``runs://`` is also accepted)
       - ``http(s)://<tracking-host>/runs/<run_id>`` (and optional artifact suffix)
         when scheme+netloc match ``mlflow_tracking_uri`` or ``MLFLOW_TRACKING_URI``
       - Legacy ``http(s)://<tracking-host>/<run_id>`` (single path segment)
@@ -854,7 +855,16 @@ def infer_mlflow_metric_step_from_lora_path(adapter_ref: str | None) -> int | No
 def extract_mlflow_run_id_from_adapter_ref(
     adapter_ref: str | None, mlflow_tracking_uri: str | None = None
 ) -> str | None:
-    """Extract MLflow run ID from adapter ref when ref points to an MLflow run."""
+    """
+    Extract MLflow run ID from adapter ref when ref points to an MLflow run.
+    
+    Args:
+        adapter_ref: The adapter reference from which to extract the MLflow run ID.
+        mlflow_tracking_uri: The MLflow tracking URI.
+
+    Returns:
+        The MLflow run ID, or ``None`` if the adapter reference does not point to an MLflow run.
+    """
     if not adapter_ref:
         return None
     parsed_url = urlparse(adapter_ref.strip(), allow_fragments=False)

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 from contextlib import contextmanager
 from inspect import signature
@@ -765,6 +766,22 @@ def get_lora_slug(adapter_ref: str, mlflow_tracking_uri: str | None = None) -> s
         adapter_ref.encode("utf-8"), digest_size=DIGEST_SIZE_FOR_PEFT_PATHS
     ).hexdigest()
     return f"adapter_{digest}"
+
+
+def infer_mlflow_metric_step_from_lora_path(adapter_ref: str | None) -> int | None:
+    """Infer MLflow metric step from LoRA adapter references containing checkpoint segments.
+
+    Matches path segments like ``checkpoint-000020`` and returns ``20``.
+    Returns ``None`` when no checkpoint segment is present.
+    """
+    if not adapter_ref:
+        return None
+
+    for segment in adapter_ref.strip().split("/"):
+        checkpoint_match = re.fullmatch(r"checkpoint-(\d+)", segment)
+        if checkpoint_match:
+            return int(checkpoint_match.group(1))
+    return None
 
 
 def config_to_dict(obj_to_convert: BaseModel, keys: list[str]) -> dict[str, Any]:

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -857,7 +857,7 @@ def extract_mlflow_run_id_from_adapter_ref(
 ) -> str | None:
     """
     Extract MLflow run ID from adapter ref when ref points to an MLflow run.
-    
+
     Args:
         adapter_ref: The adapter reference from which to extract the MLflow run ID.
         mlflow_tracking_uri: The MLflow tracking URI.

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -784,5 +784,18 @@ def infer_mlflow_metric_step_from_lora_path(adapter_ref: str | None) -> int | No
     return None
 
 
+def extract_mlflow_run_id_from_adapter_ref(
+    adapter_ref: str | None, mlflow_tracking_uri: str | None = None
+) -> str | None:
+    """Extract MLflow run ID from adapter ref when ref points to an MLflow run."""
+    if not adapter_ref:
+        return None
+    parsed_url = urlparse(adapter_ref.strip(), allow_fragments=False)
+    is_mlflow_url, run_id = check_mlflow_url(parsed_url, mlflow_tracking_uri)
+    if is_mlflow_url and run_id:
+        return run_id
+    return None
+
+
 def config_to_dict(obj_to_convert: BaseModel, keys: list[str]) -> dict[str, Any]:
     return {key: getattr(obj_to_convert, key) for key in keys}

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 from contextlib import contextmanager
+from dataclasses import dataclass
 from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -524,6 +525,68 @@ def load_transformers_model_and_tokenizer(
     return tokenizer, cast("GenerativePreTrainedModel", model)
 
 
+@dataclass(frozen=True)
+class MlflowAdapterRef:
+    """Parsed MLflow run reference with optional run-relative artifact path."""
+
+    run_id: str
+    artifact_path: str | None = None
+
+
+def parse_mlflow_adapter_url(
+    parsed_url: ParseResult, mlflow_tracking_uri: str | None
+) -> MlflowAdapterRef | None:
+    """Parse an MLflow adapter URL into a run ID and optional artifact subpath.
+
+    Supported forms:
+      - ``mlflow://<run_id>`` and ``mlflow://<run_id>/<artifact/path>``
+      - ``runs:/<run_id>`` and ``runs:/<run_id>/<artifact/path>``
+      - ``http(s)://<tracking-host>/runs/<run_id>`` (and optional artifact suffix)
+        when scheme+netloc match ``mlflow_tracking_uri`` or ``MLFLOW_TRACKING_URI``
+      - Legacy ``http(s)://<tracking-host>/<run_id>`` (single path segment)
+    """
+    scheme = parsed_url.scheme.lower()
+    path_parts = [part for part in parsed_url.path.split("/") if part]
+
+    if scheme == "mlflow":
+        run_id = parsed_url.netloc
+        if not run_id:
+            return None
+        artifact_path = parsed_url.path.lstrip("/") or None
+        return MlflowAdapterRef(run_id=run_id, artifact_path=artifact_path)
+
+    if scheme == "runs":
+        if parsed_url.netloc:
+            run_id = parsed_url.netloc
+            artifact_path = parsed_url.path.lstrip("/") or None
+        else:
+            if not path_parts:
+                return None
+            run_id = path_parts[0]
+            artifact_path = "/".join(path_parts[1:]) if len(path_parts) > 1 else None
+        return MlflowAdapterRef(run_id=run_id, artifact_path=artifact_path)
+
+    tracking_uri = mlflow_tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        return None
+
+    tracking_parsed = urlparse(tracking_uri)
+    adapter_scheme_netloc = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    tracking_scheme_netloc = f"{tracking_parsed.scheme}://{tracking_parsed.netloc}"
+    if adapter_scheme_netloc != tracking_scheme_netloc:
+        return None
+
+    if path_parts[:1] == ["runs"] and len(path_parts) >= 2:
+        run_id = path_parts[1]
+        artifact_path = "/".join(path_parts[2:]) if len(path_parts) > 2 else None
+        return MlflowAdapterRef(run_id=run_id, artifact_path=artifact_path)
+
+    if len(path_parts) == 1:
+        return MlflowAdapterRef(run_id=path_parts[0], artifact_path=None)
+
+    return None
+
+
 def check_mlflow_url(
     parsed_url: ParseResult, mlflow_tracking_uri: str | None
 ) -> tuple[bool, str | None]:
@@ -537,18 +600,10 @@ def check_mlflow_url(
     Returns:
         A tuple containing a boolean indicating if the URL is an MLflow URL and the run ID.
     """
-    run_id = None
-    tracking_uri = mlflow_tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
-    is_mlflow_scheme = parsed_url.scheme.lower() == "mlflow"
-    if is_mlflow_scheme:
-        run_id = parsed_url.netloc
-    elif not is_mlflow_scheme and tracking_uri:
-        tracking_parsed = urlparse(tracking_uri)
-        adapter_scheme_netloc = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        tracking_scheme_netloc = f"{tracking_parsed.scheme}://{tracking_parsed.netloc}"
-        is_mlflow_scheme = adapter_scheme_netloc == tracking_scheme_netloc
-        run_id = parsed_url.path.split("/")[-1]
-    return is_mlflow_scheme, run_id
+    mlflow_ref = parse_mlflow_adapter_url(parsed_url, mlflow_tracking_uri)
+    if mlflow_ref is None:
+        return False, None
+    return True, mlflow_ref.run_id
 
 
 def maybe_download_adapter(
@@ -610,9 +665,12 @@ def maybe_download_adapter(
     digest_path.mkdir(parents=True, exist_ok=True)
 
     tracking_uri = mlflow_tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
-    is_mlflow_url, run_id = check_mlflow_url(parsed_url, tracking_uri)
+    if scheme == "mlflow" and not parsed_url.netloc:
+        raise ValueError(f"Invalid mlflow ref (missing run id): {adapter_ref!r}")
 
-    if is_mlflow_url:
+    mlflow_ref = parse_mlflow_adapter_url(parsed_url, tracking_uri)
+
+    if mlflow_ref is not None:
         try:
             import mlflow
             from mlflow.artifacts import download_artifacts
@@ -621,10 +679,8 @@ def maybe_download_adapter(
                 "mlflow is required for mlflow:// refs. Install: [uv] pip install mlflow"
             ) from mlflow_exception
 
-        if not run_id:
-            raise ValueError(f"Invalid mlflow ref (missing run id): {adapter_ref!r}")
-
-        artifact_path = parsed_url.path.lstrip("/") or None
+        run_id = mlflow_ref.run_id
+        artifact_path = mlflow_ref.artifact_path
 
         if tracking_uri:
             mlflow.set_tracking_uri(tracking_uri)
@@ -757,10 +813,10 @@ def get_lora_slug(adapter_ref: str, mlflow_tracking_uri: str | None = None) -> s
 
     parsed_url = urlparse(adapter_ref, allow_fragments=False)
 
-    is_mlflow_url, run_id = check_mlflow_url(parsed_url, mlflow_tracking_uri)
+    mlflow_ref = parse_mlflow_adapter_url(parsed_url, mlflow_tracking_uri)
 
-    if is_mlflow_url and run_id:
-        return f"adapter_{run_id}"
+    if mlflow_ref is not None:
+        return f"adapter_{mlflow_ref.run_id}"
 
     digest = hashlib.blake2b(
         adapter_ref.encode("utf-8"), digest_size=DIGEST_SIZE_FOR_PEFT_PATHS
@@ -773,6 +829,17 @@ def infer_mlflow_metric_step_from_lora_path(adapter_ref: str | None) -> int | No
 
     Matches path segments like ``checkpoint-000020`` and returns ``20``.
     Returns ``None`` when no checkpoint segment is present.
+
+    Examples:
+        >>> infer_mlflow_metric_step_from_lora_path("mlflow://abc123/hf_checkpoints/checkpoint-000020")
+        20
+        >>> infer_mlflow_metric_step_from_lora_path("https://example.com/path/checkpoint-000001/adapter")
+        1
+    Args:
+        adapter_ref: The adapter reference to infer the metric step from.
+
+    Returns:
+        The metric step, or ``None`` if no checkpoint segment is present.
     """
     if not adapter_ref:
         return None
@@ -791,9 +858,9 @@ def extract_mlflow_run_id_from_adapter_ref(
     if not adapter_ref:
         return None
     parsed_url = urlparse(adapter_ref.strip(), allow_fragments=False)
-    is_mlflow_url, run_id = check_mlflow_url(parsed_url, mlflow_tracking_uri)
-    if is_mlflow_url and run_id:
-        return run_id
+    mlflow_ref = parse_mlflow_adapter_url(parsed_url, mlflow_tracking_uri)
+    if mlflow_ref is not None:
+        return mlflow_ref.run_id
     return None
 
 

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -15,6 +15,7 @@ from llm_behavior_eval.evaluation_utils.eval_config import (
     EvaluationConfig,
     MlflowConfig,
 )
+from llm_behavior_eval.evaluation_utils.vllm_config import VllmConfig
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -184,6 +185,36 @@ def test_init_mlflow_uses_existing_active_run(
     assert evaluator.mlflow_run is active_run
 
 
+def test_init_mlflow_reuses_lora_run_id_from_http_tracking_uri_ref(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    lora_run_id = "abc123def45678901234567890123456"
+    existing_run = _make_run(lora_run_id, "training")
+    existing_run.info.experiment_id = "exp-1"
+    mlflow_mock.get_run.return_value = existing_run
+    mlflow_mock.active_run.return_value = None
+    mlflow_mock.start_run.return_value = existing_run
+
+    config_with_lora = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        vllm_config=VllmConfig(),
+        judge_engine="vllm",
+        lora_path_or_repo_id=(
+            f"http://tracking.example/runs/{lora_run_id}/"
+            "hf_checkpoints/checkpoint-000020"
+        ),
+        mlflow_config=evaluation_config.mlflow_config,
+    )
+    DummyEvaluator(config_with_lora, dataset_config)
+
+    mlflow_mock.get_run.assert_called_once_with(lora_run_id)
+    mlflow_mock.start_run.assert_called_once_with(run_id=lora_run_id)
+
+
 def test_init_without_mlflow_config_does_not_touch_mlflow(
     evaluation_config_no_mlflow: EvaluationConfig,
     dataset_config: DatasetConfig,
@@ -287,7 +318,7 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     metrics_call = mlflow_mock.log_metrics.call_args
     assert metrics_call is not None
     metrics = metrics_call.args[0]
-    assert "step" not in metrics_call.kwargs
+    assert metrics_call.kwargs.get("step") is None
     assert metrics == {
         "accuracy": 0.75,
         "error": 0.25,
@@ -319,6 +350,8 @@ def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
         model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
         results_dir=evaluation_config.results_dir,
         batch_size=evaluation_config.batch_size,
+        vllm_config=VllmConfig(),
+        judge_engine="vllm",
         lora_path_or_repo_id="mlflow://abc123/hf_checkpoints/checkpoint-000020",
         mlflow_config=evaluation_config.mlflow_config,
     )
@@ -328,6 +361,7 @@ def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
     evaluator.save_results(
         responses=[{"prompt": "a", "response": "b"}],
         accuracy=0.5,
+        stereotyped_bias=None,
         empty_responses=0,
     )
 
@@ -346,6 +380,8 @@ def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step_same_run
         model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
         results_dir=evaluation_config.results_dir,
         batch_size=evaluation_config.batch_size,
+        vllm_config=VllmConfig(),
+        judge_engine="vllm",
         lora_path_or_repo_id=f"mlflow://{lora_run_id}/hf_checkpoints/checkpoint-000020",
         mlflow_config=MlflowConfig(
             mlflow_tracking_uri=evaluation_config.mlflow_config.mlflow_tracking_uri,  # type: ignore[union-attr]
@@ -362,6 +398,7 @@ def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step_same_run
     evaluator.save_results(
         responses=[{"prompt": "a", "response": "b"}],
         accuracy=0.5,
+        stereotyped_bias=None,
         empty_responses=0,
     )
 

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -333,4 +333,38 @@ def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
 
     metrics_call = mlflow_mock.log_metrics.call_args
     assert metrics_call is not None
+    assert metrics_call.kwargs.get("step") is None
+
+
+def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step_same_run(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    lora_run_id = "abc123def45678901234567890123456"
+    config_with_lora_checkpoint = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        lora_path_or_repo_id=f"mlflow://{lora_run_id}/hf_checkpoints/checkpoint-000020",
+        mlflow_config=MlflowConfig(
+            mlflow_tracking_uri=evaluation_config.mlflow_config.mlflow_tracking_uri,  # type: ignore[union-attr]
+            mlflow_experiment_name=evaluation_config.mlflow_config.mlflow_experiment_name,  # type: ignore[union-attr]
+            mlflow_run_id=lora_run_id,
+        ),
+    )
+    existing_run = _make_run(lora_run_id, "existing")
+    mlflow_mock.get_run.return_value = existing_run
+    mlflow_mock.active_run.return_value = existing_run
+    evaluator = DummyEvaluator(config_with_lora_checkpoint, dataset_config)
+    mlflow_mock.reset_mock()
+
+    evaluator.save_results(
+        responses=[{"prompt": "a", "response": "b"}],
+        accuracy=0.5,
+        empty_responses=0,
+    )
+
+    metrics_call = mlflow_mock.log_metrics.call_args
+    assert metrics_call is not None
     assert metrics_call.kwargs.get("step") == 20

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -287,6 +287,7 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     metrics_call = mlflow_mock.log_metrics.call_args
     assert metrics_call is not None
     metrics = metrics_call.args[0]
+    assert "step" not in metrics_call.kwargs
     assert metrics == {
         "accuracy": 0.75,
         "error": 0.25,
@@ -307,3 +308,29 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     assert (output_dir / "metrics.csv").exists()
     assert (uploaded_dir / "bbq-gender-bias-free-text" / "responses.json").exists()
     assert (uploaded_dir / "bbq-gender-bias-free-text" / "metrics.csv").exists()
+
+
+def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    config_with_lora_checkpoint = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        lora_path_or_repo_id="mlflow://abc123/hf_checkpoints/checkpoint-000020",
+        mlflow_config=evaluation_config.mlflow_config,
+    )
+    evaluator = DummyEvaluator(config_with_lora_checkpoint, dataset_config)
+    mlflow_mock.reset_mock()
+
+    evaluator.save_results(
+        responses=[{"prompt": "a", "response": "b"}],
+        accuracy=0.5,
+        empty_responses=0,
+    )
+
+    metrics_call = mlflow_mock.log_metrics.call_args
+    assert metrics_call is not None
+    assert metrics_call.kwargs.get("step") == 20

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -393,7 +393,7 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     assert (uploaded_dir / "bbq-gender-bias-free-text" / "metrics.csv").exists()
 
 
-def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
+def test_save_results_logs_mlflow_metrics_without_inferred_checkpoint_step(
     evaluation_config: EvaluationConfig,
     dataset_config: DatasetConfig,
     mlflow_mock: MagicMock,

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -185,6 +185,31 @@ def test_init_mlflow_uses_existing_active_run(
     assert evaluator.mlflow_run is active_run
 
 
+def test_init_mlflow_prefers_active_run_over_lora_inferred_run_id(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    active_run = _make_run("active-run", "existing")
+    mlflow_mock.active_run.return_value = active_run
+
+    config_with_lora = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        vllm_config=VllmConfig(),
+        judge_engine="vllm",
+        lora_path_or_repo_id="mlflow://abc123def45678901234567890123456",
+        mlflow_config=evaluation_config.mlflow_config,
+    )
+    evaluator = DummyEvaluator(config_with_lora, dataset_config)
+
+    mlflow_mock.get_run.assert_not_called()
+    mlflow_mock.start_run.assert_not_called()
+    assert evaluator.parent_run is active_run
+    assert evaluator.mlflow_run is active_run
+
+
 def test_init_mlflow_reuses_lora_run_id_from_http_tracking_uri_ref(
     evaluation_config: EvaluationConfig,
     dataset_config: DatasetConfig,
@@ -207,6 +232,33 @@ def test_init_mlflow_reuses_lora_run_id_from_http_tracking_uri_ref(
             f"http://tracking.example/runs/{lora_run_id}/"
             "hf_checkpoints/checkpoint-000020"
         ),
+        mlflow_config=evaluation_config.mlflow_config,
+    )
+    DummyEvaluator(config_with_lora, dataset_config)
+
+    mlflow_mock.get_run.assert_called_once_with(lora_run_id)
+    mlflow_mock.start_run.assert_called_once_with(run_id=lora_run_id)
+
+
+def test_init_mlflow_reuses_lora_run_id_when_no_user_or_active_run(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    lora_run_id = "abc123def45678901234567890123456"
+    existing_run = _make_run(lora_run_id, "training")
+    existing_run.info.experiment_id = "exp-1"
+    mlflow_mock.get_run.return_value = existing_run
+    mlflow_mock.active_run.return_value = None
+    mlflow_mock.start_run.return_value = existing_run
+
+    config_with_lora = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        vllm_config=VllmConfig(),
+        judge_engine="vllm",
+        lora_path_or_repo_id=f"mlflow://{lora_run_id}",
         mlflow_config=evaluation_config.mlflow_config,
     )
     DummyEvaluator(config_with_lora, dataset_config)

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -9,6 +9,7 @@ import torch
 from llm_behavior_eval.evaluation_utils.util_functions import (
     build_vllm_prompt_token_ids,
     get_lora_slug,
+    infer_mlflow_metric_step_from_lora_path,
     is_model_multimodal,
     maybe_download_adapter,
     pick_best_dtype,
@@ -280,6 +281,23 @@ def test_get_lora_slug_uses_mlflow_run_id_for_matching_tracking_uri() -> None:
     adapter_ref = f"http://mlflow.example.com/runs/{run_id}"
     slug = get_lora_slug(adapter_ref, mlflow_tracking_uri="http://mlflow.example.com")
     assert slug == f"adapter_{run_id}"
+
+
+@pytest.mark.parametrize(
+    ("adapter_ref", "expected_step"),
+    [
+        ("mlflow://abc123/hf_checkpoints/checkpoint-000020", 20),
+        ("mlflow://abc123/checkpoint-40", 40),
+        ("https://example.com/path/checkpoint-000001/adapter", 1),
+        ("/tmp/my_adapter", None),
+        ("mlflow://abc123/no-checkpoint-here", None),
+        (None, None),
+    ],
+)
+def test_infer_mlflow_metric_step_from_lora_path(
+    adapter_ref: str | None, expected_step: int | None
+) -> None:
+    assert infer_mlflow_metric_step_from_lora_path(adapter_ref) == expected_step
 
 
 def test_maybe_download_adapter_mlflow_scheme_missing_mlflow(

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -407,7 +407,9 @@ def test_maybe_download_adapter_mlflow_scheme_with_run_id(
 
     def mock_download_artifacts(*args, **kwargs) -> str:
         call_run_id = kwargs.get("run_id", args[0] if args else "")
-        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_artifact_path = kwargs.get(
+            "artifact_path", args[1] if len(args) > 1 else ""
+        )
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
         mock_download_artifacts_calls.append(
             (call_run_id, call_artifact_path, dst_path)
@@ -440,7 +442,9 @@ def test_maybe_download_adapter_mlflow_scheme_default_artifact_paths(
 
     def mock_download_artifacts(*args, **kwargs) -> str:
         call_run_id = kwargs.get("run_id", args[0] if args else "")
-        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_artifact_path = kwargs.get(
+            "artifact_path", args[1] if len(args) > 1 else ""
+        )
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
         mock_download_artifacts_calls.append(
             (call_run_id, call_artifact_path, dst_path)
@@ -473,7 +477,9 @@ def test_maybe_download_adapter_http_with_mlflow_run_id(
 
     def mock_download_artifacts(*args, **kwargs) -> str:
         call_run_id = kwargs.get("run_id", args[0] if args else "")
-        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_artifact_path = kwargs.get(
+            "artifact_path", args[1] if len(args) > 1 else ""
+        )
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
         mock_download_artifacts_calls.append(
             (call_run_id, call_artifact_path, dst_path)

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -284,6 +284,15 @@ def test_get_lora_slug_uses_mlflow_run_id_for_matching_tracking_uri() -> None:
     assert slug == f"adapter_{run_id}"
 
 
+def test_get_lora_slug_uses_run_id_not_checkpoint_for_tracking_uri_subpath() -> None:
+    run_id = "abc123def45678901234567890123456"
+    adapter_ref = (
+        f"http://mlflow.example.com/runs/{run_id}/hf_checkpoints/checkpoint-000020"
+    )
+    slug = get_lora_slug(adapter_ref, mlflow_tracking_uri="http://mlflow.example.com")
+    assert slug == f"adapter_{run_id}"
+
+
 @pytest.mark.parametrize(
     ("adapter_ref", "expected_step"),
     [
@@ -311,6 +320,27 @@ def test_extract_mlflow_run_id_from_adapter_ref_mlflow_scheme() -> None:
 
 def test_extract_mlflow_run_id_from_adapter_ref_non_mlflow_path() -> None:
     assert extract_mlflow_run_id_from_adapter_ref("/tmp/checkpoint-1") is None
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_http_tracking_uri_subpath() -> None:
+    run_id = "abc123def45678901234567890123456"
+    adapter_ref = (
+        f"http://mlflow.example.com/runs/{run_id}/hf_checkpoints/checkpoint-000020"
+    )
+    assert (
+        extract_mlflow_run_id_from_adapter_ref(
+            adapter_ref, mlflow_tracking_uri="http://mlflow.example.com"
+        )
+        == run_id
+    )
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_runs_scheme() -> None:
+    run_id = "abc123def45678901234567890123456"
+    assert (
+        extract_mlflow_run_id_from_adapter_ref(f"runs:/{run_id}/hf_checkpoint/peft")
+        == run_id
+    )
 
 
 def test_maybe_download_adapter_mlflow_scheme_missing_mlflow(
@@ -492,10 +522,59 @@ def test_maybe_download_adapter_http_with_mlflow_run_id(
             mlflow_tracking_uri="http://mlflow.example.com",
         )
 
-        assert len(mock_download_artifacts_calls) == 1
+        assert mock_download_artifacts_calls
         assert mock_download_artifacts_calls[0][0] == run_id
+        assert mock_download_artifacts_calls[0][1] == "hf_checkpoint/peft"
     finally:
         # Clean up
+        if "mlflow" in sys.modules:
+            del sys.modules["mlflow"]
+        if "mlflow.artifacts" in sys.modules:
+            del sys.modules["mlflow.artifacts"]
+
+
+def test_maybe_download_adapter_http_tracking_uri_with_artifact_subpath(
+    tmp_path: Path,
+) -> None:
+    """HTTP tracking URI refs parse /runs/<run_id>/<artifact> for download."""
+    import sys
+
+    run_id = "abc123def45678901234567890123456"
+    artifact_path = "hf_checkpoints/checkpoint-000020"
+    mock_download_artifacts_calls: list[tuple[str, str, str]] = []
+
+    def mock_download_artifacts(*args: object, **kwargs: object) -> str:
+        call_run_id = str(kwargs.get("run_id", args[0] if args else ""))
+        call_artifact_path = str(
+            kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        )
+        dst_path = str(kwargs.get("dst_path", args[2] if len(args) > 2 else ""))
+        mock_download_artifacts_calls.append(
+            (call_run_id, call_artifact_path, dst_path)
+        )
+        result_dir = Path(dst_path) / call_artifact_path
+        result_dir.mkdir(parents=True, exist_ok=True)
+        return str(result_dir)
+
+    mock_mlflow = types.ModuleType("mlflow")
+    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
+    mock_artifacts = types.ModuleType("mlflow.artifacts")
+    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+
+    sys.modules["mlflow"] = mock_mlflow
+    sys.modules["mlflow.artifacts"] = mock_artifacts
+
+    try:
+        maybe_download_adapter(
+            f"http://mlflow.example.com/runs/{run_id}/{artifact_path}",
+            cache_dir=str(tmp_path),
+            mlflow_tracking_uri="http://mlflow.example.com",
+        )
+
+        assert len(mock_download_artifacts_calls) == 1
+        assert mock_download_artifacts_calls[0][0] == run_id
+        assert mock_download_artifacts_calls[0][1] == artifact_path
+    finally:
         if "mlflow" in sys.modules:
             del sys.modules["mlflow"]
         if "mlflow.artifacts" in sys.modules:

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -1,7 +1,9 @@
 import sys
 import types
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -20,6 +22,23 @@ from llm_behavior_eval.evaluation_utils.util_functions import (
 
 if TYPE_CHECKING:
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+
+def _patch_mlflow_for_lazy_import(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    download_artifacts: Callable[..., str],
+    set_tracking_uri: Callable[[str], None] | None = None,
+) -> MagicMock:
+    """Stub mlflow for lazy imports inside maybe_download_adapter."""
+    mock_mlflow = MagicMock()
+    mock_artifacts = MagicMock()
+    mock_artifacts.download_artifacts.side_effect = download_artifacts
+    if set_tracking_uri is not None:
+        mock_mlflow.set_tracking_uri.side_effect = set_tracking_uri
+    monkeypatch.setitem(sys.modules, "mlflow", mock_mlflow)
+    monkeypatch.setitem(sys.modules, "mlflow.artifacts", mock_artifacts)
+    return mock_artifacts
 
 
 class MockConfig:
@@ -368,75 +387,47 @@ def test_maybe_download_adapter_mlflow_scheme_no_run_id(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """Test that mlflow:// without run_id raises ValueError."""
-    # Mock mlflow import - need to mock sys.modules since it's imported inside the function
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch,
+        download_artifacts=lambda run_id, artifact_path, dst_path: str(dst_path),
+    )
 
-    def mock_download_artifacts(run_id, artifact_path, dst_path):
-        return str(dst_path)
-
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
-
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
-
-    try:
-        with pytest.raises(ValueError, match="Invalid mlflow ref \\(missing run id\\)"):
-            maybe_download_adapter("mlflow://")
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    with pytest.raises(ValueError, match="Invalid mlflow ref \\(missing run id\\)"):
+        maybe_download_adapter("mlflow://")
 
 
 def test_maybe_download_adapter_mlflow_scheme_with_run_id(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """Test mlflow:// scheme with run_id downloads artifacts."""
-    import sys
-
     run_id = "abc123def45678901234567890123456"
     artifact_path = "hf_checkpoint/peft"
 
-    # Mock mlflow
     mock_download_artifacts_calls: list[tuple[str, str, str]] = []
 
     def mock_download_artifacts(*args, **kwargs) -> str:
-        run_id = kwargs.get("run_id", args[0] if args else "")
-        artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_run_id = kwargs.get("run_id", args[0] if args else "")
+        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
-        mock_download_artifacts_calls.append((run_id, artifact_path, dst_path))
-        # Create the directory structure - return the directory, not a file
-        result_dir = Path(dst_path) / artifact_path
+        mock_download_artifacts_calls.append(
+            (call_run_id, call_artifact_path, dst_path)
+        )
+        result_dir = Path(dst_path) / call_artifact_path
         result_dir.mkdir(parents=True, exist_ok=True)
         return str(result_dir)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch, download_artifacts=mock_download_artifacts
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
+    result = maybe_download_adapter(
+        f"mlflow://{run_id}/{artifact_path}", cache_dir=str(tmp_path)
+    )
 
-    try:
-        result = maybe_download_adapter(
-            f"mlflow://{run_id}/{artifact_path}", cache_dir=str(tmp_path)
-        )
-
-        assert len(mock_download_artifacts_calls) == 1
-        assert mock_download_artifacts_calls[0][0] == run_id
-        assert mock_download_artifacts_calls[0][1] == artifact_path
-        assert "peft_adapters" in result
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    assert len(mock_download_artifacts_calls) == 1
+    assert mock_download_artifacts_calls[0][0] == run_id
+    assert mock_download_artifacts_calls[0][1] == artifact_path
+    assert "peft_adapters" in result
 
 
 def test_maybe_download_adapter_mlflow_scheme_default_artifact_paths(
@@ -445,100 +436,74 @@ def test_maybe_download_adapter_mlflow_scheme_default_artifact_paths(
     """Test mlflow:// scheme tries default artifact paths when none specified."""
     run_id = "abc123def45678901234567890123456"
 
-    # Mock mlflow - first call fails, second succeeds
     mock_download_artifacts_calls: list[tuple[str, str, str]] = []
 
     def mock_download_artifacts(*args, **kwargs) -> str:
-        run_id = kwargs.get("run_id", args[0] if args else "")
-        artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_run_id = kwargs.get("run_id", args[0] if args else "")
+        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
-        mock_download_artifacts_calls.append((run_id, artifact_path, dst_path))
-        if artifact_path == "hf_checkpoint/peft":
+        mock_download_artifacts_calls.append(
+            (call_run_id, call_artifact_path, dst_path)
+        )
+        if call_artifact_path == "hf_checkpoint/peft":
             raise Exception("Not found")
-        # Create the directory structure - return the directory
-        result_dir = Path(dst_path) / artifact_path
+        result_dir = Path(dst_path) / call_artifact_path
         result_dir.mkdir(parents=True, exist_ok=True)
         return str(result_dir)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch, download_artifacts=mock_download_artifacts
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
+    result = maybe_download_adapter(f"mlflow://{run_id}", cache_dir=str(tmp_path))
 
-    try:
-        result = maybe_download_adapter(f"mlflow://{run_id}", cache_dir=str(tmp_path))
-
-        assert len(mock_download_artifacts_calls) == 2
-        assert mock_download_artifacts_calls[0][1] == "hf_checkpoint/peft"
-        assert mock_download_artifacts_calls[1][1] == "hf_checkpoint"
-        assert "hf_checkpoint" in result
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    assert len(mock_download_artifacts_calls) == 2
+    assert mock_download_artifacts_calls[0][1] == "hf_checkpoint/peft"
+    assert mock_download_artifacts_calls[1][1] == "hf_checkpoint"
+    assert "hf_checkpoint" in result
 
 
 def test_maybe_download_adapter_http_with_mlflow_run_id(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """Test http:// URL with mlflow run_id in path."""
-    import sys
-    import types
-
     run_id = "abc123def45678901234567890123456"
 
     mock_download_artifacts_calls: list[tuple[str, str, str]] = []
 
     def mock_download_artifacts(*args, **kwargs) -> str:
-        run_id = kwargs.get("run_id", args[0] if args else "")
-        artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
+        call_run_id = kwargs.get("run_id", args[0] if args else "")
+        call_artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
-        mock_download_artifacts_calls.append((run_id, artifact_path, dst_path))
-        # For http URLs, artifact_path might be the full path, so handle it
-        if artifact_path:
-            result_dir = Path(dst_path) / artifact_path
+        mock_download_artifacts_calls.append(
+            (call_run_id, call_artifact_path, dst_path)
+        )
+        if call_artifact_path:
+            result_dir = Path(dst_path) / call_artifact_path
         else:
             result_dir = Path(dst_path)
         result_dir.mkdir(parents=True, exist_ok=True)
         return str(result_dir)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch, download_artifacts=mock_download_artifacts
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
+    maybe_download_adapter(
+        f"http://mlflow.example.com/runs/{run_id}",
+        cache_dir=str(tmp_path),
+        mlflow_tracking_uri="http://mlflow.example.com",
+    )
 
-    try:
-        maybe_download_adapter(
-            f"http://mlflow.example.com/runs/{run_id}",
-            cache_dir=str(tmp_path),
-            mlflow_tracking_uri="http://mlflow.example.com",
-        )
-
-        assert mock_download_artifacts_calls
-        assert mock_download_artifacts_calls[0][0] == run_id
-        assert mock_download_artifacts_calls[0][1] == "hf_checkpoint/peft"
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    assert mock_download_artifacts_calls
+    assert mock_download_artifacts_calls[0][0] == run_id
+    assert mock_download_artifacts_calls[0][1] == "hf_checkpoint/peft"
 
 
 def test_maybe_download_adapter_http_tracking_uri_with_artifact_subpath(
-    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """HTTP tracking URI refs parse /runs/<run_id>/<artifact> for download."""
-    import sys
-
     run_id = "abc123def45678901234567890123456"
     artifact_path = "hf_checkpoints/checkpoint-000020"
     mock_download_artifacts_calls: list[tuple[str, str, str]] = []
@@ -556,64 +521,40 @@ def test_maybe_download_adapter_http_tracking_uri_with_artifact_subpath(
         result_dir.mkdir(parents=True, exist_ok=True)
         return str(result_dir)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch, download_artifacts=mock_download_artifacts
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
+    maybe_download_adapter(
+        f"http://mlflow.example.com/runs/{run_id}/{artifact_path}",
+        cache_dir=str(tmp_path),
+        mlflow_tracking_uri="http://mlflow.example.com",
+    )
 
-    try:
-        maybe_download_adapter(
-            f"http://mlflow.example.com/runs/{run_id}/{artifact_path}",
-            cache_dir=str(tmp_path),
-            mlflow_tracking_uri="http://mlflow.example.com",
-        )
-
-        assert len(mock_download_artifacts_calls) == 1
-        assert mock_download_artifacts_calls[0][0] == run_id
-        assert mock_download_artifacts_calls[0][1] == artifact_path
-    finally:
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    assert len(mock_download_artifacts_calls) == 1
+    assert mock_download_artifacts_calls[0][0] == run_id
+    assert mock_download_artifacts_calls[0][1] == artifact_path
 
 
 def test_maybe_download_adapter_mlflow_artifact_is_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """Test that mlflow artifact pointing to file raises ValueError."""
-    import sys
-
     run_id = "abc123def45678901234567890123456"
 
     def mock_download_artifacts(*args, **kwargs) -> str:
-        # Return a file path instead of directory
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
         file_path = Path(dst_path) / "file.txt"
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text("test")
         return str(file_path)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = lambda uri: None  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch, download_artifacts=mock_download_artifacts
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
-
-    try:
-        with pytest.raises(ValueError, match="MLflow artifact resolved to a file"):
-            maybe_download_adapter(f"mlflow://{run_id}", cache_dir=str(tmp_path))
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    with pytest.raises(ValueError, match="MLflow artifact resolved to a file"):
+        maybe_download_adapter(f"mlflow://{run_id}", cache_dir=str(tmp_path))
 
 
 def test_maybe_download_adapter_git_scheme_missing_gitpython(
@@ -905,7 +846,6 @@ def test_maybe_download_adapter_mlflow_tracking_uri(
     def mock_download_artifacts(*args, **kwargs) -> str:
         artifact_path = kwargs.get("artifact_path", args[1] if len(args) > 1 else "")
         dst_path = kwargs.get("dst_path", args[2] if len(args) > 2 else "")
-        # Return a directory, not a file
         if artifact_path:
             result_dir = Path(dst_path) / artifact_path
         else:
@@ -913,25 +853,16 @@ def test_maybe_download_adapter_mlflow_tracking_uri(
         result_dir.mkdir(parents=True, exist_ok=True)
         return str(result_dir)
 
-    mock_mlflow = types.ModuleType("mlflow")
-    mock_mlflow.set_tracking_uri = mock_set_tracking_uri  # type: ignore[attr-defined]
-    mock_artifacts = types.ModuleType("mlflow.artifacts")
-    mock_artifacts.download_artifacts = mock_download_artifacts  # type: ignore[attr-defined]
+    _patch_mlflow_for_lazy_import(
+        monkeypatch,
+        download_artifacts=mock_download_artifacts,
+        set_tracking_uri=mock_set_tracking_uri,
+    )
 
-    sys.modules["mlflow"] = mock_mlflow
-    sys.modules["mlflow.artifacts"] = mock_artifacts
+    maybe_download_adapter(
+        f"mlflow://{run_id}",
+        cache_dir=str(tmp_path),
+        mlflow_tracking_uri=tracking_uri,
+    )
 
-    try:
-        maybe_download_adapter(
-            f"mlflow://{run_id}",
-            cache_dir=str(tmp_path),
-            mlflow_tracking_uri=tracking_uri,
-        )
-
-        assert tracking_uri in mock_set_tracking_uri_calls
-    finally:
-        # Clean up
-        if "mlflow" in sys.modules:
-            del sys.modules["mlflow"]
-        if "mlflow.artifacts" in sys.modules:
-            del sys.modules["mlflow.artifacts"]
+    assert tracking_uri in mock_set_tracking_uri_calls

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -8,6 +8,7 @@ import torch
 
 from llm_behavior_eval.evaluation_utils.util_functions import (
     build_vllm_prompt_token_ids,
+    extract_mlflow_run_id_from_adapter_ref,
     get_lora_slug,
     infer_mlflow_metric_step_from_lora_path,
     is_model_multimodal,
@@ -298,6 +299,18 @@ def test_infer_mlflow_metric_step_from_lora_path(
     adapter_ref: str | None, expected_step: int | None
 ) -> None:
     assert infer_mlflow_metric_step_from_lora_path(adapter_ref) == expected_step
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_mlflow_scheme() -> None:
+    run_id = "abc123def45678901234567890123456"
+    assert (
+        extract_mlflow_run_id_from_adapter_ref(f"mlflow://{run_id}/checkpoint-1")
+        == run_id
+    )
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_non_mlflow_path() -> None:
+    assert extract_mlflow_run_id_from_adapter_ref("/tmp/checkpoint-1") is None
 
 
 def test_maybe_download_adapter_mlflow_scheme_missing_mlflow(


### PR DESCRIPTION
# User description
### Motivation
- Ensure MLflow metrics are logged with a meaningful `step` when evaluating LoRA adapters that come from model checkpoint artifacts (e.g., `checkpoint-000020`) so metric histories reflect checkpoint progression.
- Infer the checkpoint step automatically from the existing `lora_path_or_repo_id` input without adding CLI flags and preserve existing behavior when no checkpoint is present.

### Description
- Added `infer_mlflow_metric_step_from_lora_path(adapter_ref)` in `llm_behavior_eval/evaluation_utils/util_functions.py` that scans path segments for `checkpoint-<digits>` and returns the integer step or `None`.
- Wired the inference into `BaseEvaluator` initialization, storing the value in `self._inferred_mlflow_metric_step` and emitting an INFO log when a step is found.
- Updated `_log_mlflow_metrics(...)` in `BaseEvaluator` to call `mlflow.log_metrics(metrics, step=...)` only when an inferred step exists and otherwise keep the prior behavior.
- Added unit tests in `tests/test_util_functions.py` for the parser and an integration-style test in `tests/test_mlflow_integration.py` asserting both no-step default behavior and that an inferred checkpoint step results in `log_metrics` being called with the expected `step` kwarg.

### Testing
- Added automated tests that exercise the parser and MLflow logging behavior as described in the Description section.
- Ran `pytest` targeting the new parser test and MLflow integration test in this environment, but test collection failed with `ModuleNotFoundError: No module named 'torch'`, preventing the tests from executing here.
- All new tests are unit-style and rely on existing test fixtures and MLflow mocks and should pass in CI where project dependencies (including `torch`) are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17fc59e9bc832d8f31bef112d4770e)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Infer checkpoint steps from LoRA adapter refs and feed them into <code>BaseEvaluator</code> so MLflow metrics log with a meaningful <code>step</code> whenever reusing the adapter run. Add adapter parsing utilities in <code>util_functions</code> and cover both the parser and MLflow logging behavior through targeted unit tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/130?tool=ast&topic=MLflow+Step+Handling>MLflow Step Handling</a>
        </td><td>Log metrics in <code>BaseEvaluator</code> using the inferred checkpoint step only when the active MLflow run matches the LoRA adapter run, and attach existing runs inferred from adapter refs so checkpoint progress is preserved in histories.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>tests/test_mlflow_integration.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>moved location of method</td><td>June 01, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-93: Add finish rea...</td><td>May 20, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/130?tool=ast&topic=Adapter+Parsing>Adapter Parsing</a>
        </td><td>Parse MLflow adapter refs to extract run IDs and checkpoint segments, and validate the new parser plus slug/ID helpers through unit tests.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/util_functions.py</li>
<li>tests/test_util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>linting + minor docstr...</td><td>May 31, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-70: Add support fo...</td><td>May 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/130?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>