### PR TITLE
LLM-99: Infer MLflow run and metric step from LoRA adapter refs

### DIFF
--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -31,7 +31,9 @@ from .max_batch_size import MAX_BATCH_SIZE
 from .sampling_config import SamplingConfig
 from .util_functions import (
     empty_cuda_cache_if_available,
+    extract_mlflow_run_id_from_adapter_ref,
     get_lora_slug,
+    infer_mlflow_metric_step_from_lora_path,
     load_tokenizer_with_transformers,
 )
 
@@ -121,8 +123,25 @@ class BaseEvaluator(ABC):
         self.mlflow_run = None
         self.parent_run = None
         self._started_mlflow_run = False
+        self._inferred_mlflow_metric_step: int | None = None
+        inferred_step = infer_mlflow_metric_step_from_lora_path(
+            self.eval_config.lora_path_or_repo_id
+        )
+        if inferred_step is not None:
+            logging.info(
+                "Inferred MLflow metric step %s from LoRA checkpoint path %s",
+                inferred_step,
+                self.eval_config.lora_path_or_repo_id,
+            )
+        self._lora_mlflow_run_id = extract_mlflow_run_id_from_adapter_ref(
+            self.eval_config.lora_path_or_repo_id,
+            self.mlflow_config.mlflow_tracking_uri if self.mlflow_config else None,
+        )
         if self.mlflow_config:
             self._init_mlflow()
+            self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
+                inferred_step
+            )
 
         self.data_collator = default_data_collator
         if self.model_engine == "vllm":
@@ -703,6 +722,12 @@ class BaseEvaluator(ABC):
         model_slug = self.get_model_slug()
 
         requested_run_id = self.mlflow_config.mlflow_run_id
+        if not requested_run_id and self._lora_mlflow_run_id:
+            requested_run_id = self._lora_mlflow_run_id
+            logging.info(
+                "No mlflow_run_id provided; reusing LoRA source run %s for metric logging",
+                requested_run_id,
+            )
         active_run = mlflow.active_run()
 
         if requested_run_id:
@@ -773,7 +798,27 @@ class BaseEvaluator(ABC):
         """Log evaluation metrics to MLflow."""
         if not self.eval_config.mlflow_config or not mlflow:
             return
+        if self._inferred_mlflow_metric_step is not None:
+            mlflow.log_metrics(metrics, step=self._inferred_mlflow_metric_step)
+            return
         mlflow.log_metrics(metrics)
+
+    def _resolve_mlflow_metric_step(self, inferred_step: int | None) -> int | None:
+        """Use inferred checkpoint step only when logging back to same MLflow run."""
+        if inferred_step is None:
+            return None
+        if self._lora_mlflow_run_id is None:
+            return None
+        current_run_id = self.parent_run.info.run_id if self.parent_run else None
+        if current_run_id == self._lora_mlflow_run_id:
+            return inferred_step
+        logging.info(
+            "Skipping inferred MLflow metric step %s: LoRA run %s differs from logging run %s",
+            inferred_step,
+            self._lora_mlflow_run_id,
+            current_run_id,
+        )
+        return None
 
     def _sanitize_mlflow_key(self, name: str) -> str:
         """Return a key safe for MLflow params/metrics: alphanumeric and underscores only.

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 from contextlib import contextmanager
 from inspect import signature
@@ -765,6 +766,35 @@ def get_lora_slug(adapter_ref: str, mlflow_tracking_uri: str | None = None) -> s
         adapter_ref.encode("utf-8"), digest_size=DIGEST_SIZE_FOR_PEFT_PATHS
     ).hexdigest()
     return f"adapter_{digest}"
+
+
+def infer_mlflow_metric_step_from_lora_path(adapter_ref: str | None) -> int | None:
+    """Infer MLflow metric step from LoRA adapter references containing checkpoint segments.
+
+    Matches path segments like ``checkpoint-000020`` and returns ``20``.
+    Returns ``None`` when no checkpoint segment is present.
+    """
+    if not adapter_ref:
+        return None
+
+    for segment in adapter_ref.strip().split("/"):
+        checkpoint_match = re.fullmatch(r"checkpoint-(\d+)", segment)
+        if checkpoint_match:
+            return int(checkpoint_match.group(1))
+    return None
+
+
+def extract_mlflow_run_id_from_adapter_ref(
+    adapter_ref: str | None, mlflow_tracking_uri: str | None = None
+) -> str | None:
+    """Extract MLflow run ID from adapter ref when ref points to an MLflow run."""
+    if not adapter_ref:
+        return None
+    parsed_url = urlparse(adapter_ref.strip(), allow_fragments=False)
+    is_mlflow_url, run_id = check_mlflow_url(parsed_url, mlflow_tracking_uri)
+    if is_mlflow_url and run_id:
+        return run_id
+    return None
 
 
 def config_to_dict(obj_to_convert: BaseModel, keys: list[str]) -> dict[str, Any]:

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -287,6 +287,7 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     metrics_call = mlflow_mock.log_metrics.call_args
     assert metrics_call is not None
     metrics = metrics_call.args[0]
+    assert "step" not in metrics_call.kwargs
     assert metrics == {
         "accuracy": 0.75,
         "error": 0.25,
@@ -307,3 +308,89 @@ def test_save_results_logs_mlflow_metrics_and_artifacts(
     assert (output_dir / "metrics.csv").exists()
     assert (uploaded_dir / "bbq-gender-bias-free-text" / "responses.json").exists()
     assert (uploaded_dir / "bbq-gender-bias-free-text" / "metrics.csv").exists()
+
+
+def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    config_with_lora_checkpoint = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        lora_path_or_repo_id="mlflow://abc123/hf_checkpoints/checkpoint-000020",
+        mlflow_config=evaluation_config.mlflow_config,
+    )
+    evaluator = DummyEvaluator(config_with_lora_checkpoint, dataset_config)
+    mlflow_mock.reset_mock()
+
+    evaluator.save_results(
+        responses=[{"prompt": "a", "response": "b"}],
+        accuracy=0.5,
+        empty_responses=0,
+    )
+
+    metrics_call = mlflow_mock.log_metrics.call_args
+    assert metrics_call is not None
+    assert metrics_call.kwargs.get("step") is None
+
+
+def test_save_results_logs_mlflow_metrics_with_inferred_checkpoint_step_same_run(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    lora_run_id = "abc123def45678901234567890123456"
+    config_with_lora_checkpoint = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        lora_path_or_repo_id=f"mlflow://{lora_run_id}/hf_checkpoints/checkpoint-000020",
+        mlflow_config=MlflowConfig(
+            mlflow_tracking_uri=evaluation_config.mlflow_config.mlflow_tracking_uri,  # type: ignore[union-attr]
+            mlflow_experiment_name=evaluation_config.mlflow_config.mlflow_experiment_name,  # type: ignore[union-attr]
+            mlflow_run_id=lora_run_id,
+        ),
+    )
+    existing_run = _make_run(lora_run_id, "existing")
+    mlflow_mock.get_run.return_value = existing_run
+    mlflow_mock.active_run.return_value = existing_run
+    evaluator = DummyEvaluator(config_with_lora_checkpoint, dataset_config)
+    mlflow_mock.reset_mock()
+
+    evaluator.save_results(
+        responses=[{"prompt": "a", "response": "b"}],
+        accuracy=0.5,
+        empty_responses=0,
+    )
+
+    metrics_call = mlflow_mock.log_metrics.call_args
+    assert metrics_call is not None
+    assert metrics_call.kwargs.get("step") == 20
+
+
+def test_init_mlflow_infers_run_id_from_lora_ref_when_not_provided(
+    evaluation_config: EvaluationConfig,
+    dataset_config: DatasetConfig,
+    mlflow_mock: MagicMock,
+) -> None:
+    lora_run_id = "abc123def45678901234567890123456"
+    config_with_lora_mlflow_run = EvaluationConfig(
+        model_path_or_repo_id=evaluation_config.model_path_or_repo_id,
+        results_dir=evaluation_config.results_dir,
+        batch_size=evaluation_config.batch_size,
+        lora_path_or_repo_id=f"mlflow://{lora_run_id}/hf_checkpoints/checkpoint-000020",
+        mlflow_config=MlflowConfig(
+            mlflow_tracking_uri=evaluation_config.mlflow_config.mlflow_tracking_uri,  # type: ignore[union-attr]
+            mlflow_experiment_name=evaluation_config.mlflow_config.mlflow_experiment_name,  # type: ignore[union-attr]
+        ),
+    )
+    existing_run = _make_run(lora_run_id, "existing")
+    mlflow_mock.active_run.return_value = None
+    mlflow_mock.get_run.return_value = existing_run
+
+    DummyEvaluator(config_with_lora_mlflow_run, dataset_config)
+
+    mlflow_mock.get_run.assert_called_once_with(lora_run_id)
+    mlflow_mock.start_run.assert_called()

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -8,7 +8,9 @@ import torch
 
 from llm_behavior_eval.evaluation_utils.util_functions import (
     build_vllm_prompt_token_ids,
+    extract_mlflow_run_id_from_adapter_ref,
     get_lora_slug,
+    infer_mlflow_metric_step_from_lora_path,
     is_model_multimodal,
     maybe_download_adapter,
     pick_best_dtype,
@@ -280,6 +282,35 @@ def test_get_lora_slug_uses_mlflow_run_id_for_matching_tracking_uri() -> None:
     adapter_ref = f"http://mlflow.example.com/runs/{run_id}"
     slug = get_lora_slug(adapter_ref, mlflow_tracking_uri="http://mlflow.example.com")
     assert slug == f"adapter_{run_id}"
+
+
+@pytest.mark.parametrize(
+    ("adapter_ref", "expected_step"),
+    [
+        ("mlflow://abc123/hf_checkpoints/checkpoint-000020", 20),
+        ("mlflow://abc123/checkpoint-40", 40),
+        ("https://example.com/path/checkpoint-000001/adapter", 1),
+        ("/tmp/my_adapter", None),
+        ("mlflow://abc123/no-checkpoint-here", None),
+        (None, None),
+    ],
+)
+def test_infer_mlflow_metric_step_from_lora_path(
+    adapter_ref: str | None, expected_step: int | None
+) -> None:
+    assert infer_mlflow_metric_step_from_lora_path(adapter_ref) == expected_step
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_mlflow_scheme() -> None:
+    run_id = "abc123def45678901234567890123456"
+    assert (
+        extract_mlflow_run_id_from_adapter_ref(f"mlflow://{run_id}/checkpoint-1")
+        == run_id
+    )
+
+
+def test_extract_mlflow_run_id_from_adapter_ref_non_mlflow_path() -> None:
+    assert extract_mlflow_run_id_from_adapter_ref("/tmp/checkpoint-1") is None
 
 
 def test_maybe_download_adapter_mlflow_scheme_missing_mlflow(


### PR DESCRIPTION
# User description
### Motivation

- Ensure metrics logged to MLflow can be associated with the correct checkpoint step when evaluating models that reference LoRA adapters with checkpoint segments.
- Allow reusing an existing MLflow run referenced in a LoRA adapter URI when no explicit `mlflow_run_id` is provided so metrics/artifacts attach to the original run.

### Description

- Added `infer_mlflow_metric_step_from_lora_path` and `extract_mlflow_run_id_from_adapter_ref` to `util_functions.py` to parse checkpoint steps (e.g. `checkpoint-000020` -> `20`) and extract MLflow run IDs from `mlflow://` or matching tracking URIs.
- Wired the new utilities into `BaseEvaluator` to infer a candidate metric `step` and the LoRA run ID at initialization time and logged informational messages when inference occurs.
- Implemented `_resolve_mlflow_metric_step` to ensure an inferred step is only applied when logging back to the same MLflow run as the LoRA source, and used `_inferred_mlflow_metric_step` in `_log_mlflow_metrics` to pass `step` to `mlflow.log_metrics` when applicable.
- If no explicit `mlflow_run_id` is provided, `BaseEvaluator._init_mlflow` will reuse the MLflow run ID inferred from the LoRA ref when available.

### Testing

- Added unit tests in `tests/test_util_functions.py` covering `infer_mlflow_metric_step_from_lora_path` and `extract_mlflow_run_id_from_adapter_ref` and in `tests/test_mlflow_integration.py` covering inferred checkpoint step handling and run-ID reuse during MLflow initialization.
- Ran the updated test suite (`tests/test_util_functions.py` and `tests/test_mlflow_integration.py`), and all new and existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17fc59e9bc832d8f31bef112d4770e)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add utilities in <code>util_functions.py</code> to parse LoRA adapter references for checkpoint steps and MLflow run IDs, enabling evaluator logic to infer logging context. Wire <code>BaseEvaluator</code> to reuse inferred run IDs, resolve inferred metric steps, and pass them when logging to MLflow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/131?tool=ast&topic=MLflow+tests>MLflow tests</a>
        </td><td>Validate the new inference flow by checking inferred steps and run reuse in the MLflow integration tests and the utility helpers’ unit tests.<details><summary>Modified files (2)</summary><ul><li>tests/test_mlflow_integration.py</li>
<li>tests/test_util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>Infer MLflow destinati...</td><td>May 28, 2026</td></tr>
<tr><td>ddishi</td><td>LLM-86: Remove pytest ...</td><td>May 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/131?tool=ast&topic=MLflow+context>MLflow context</a>
        </td><td>Infer LoRA checkpoint steps and run IDs via <code>infer_mlflow_metric_step_from_lora_path</code> and <code>extract_mlflow_run_id_from_adapter_ref</code>, then apply them in <code>BaseEvaluator</code> to reuse the original run and resolve metric steps when logging.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>orr@hirundo.io</td><td>Infer MLflow destinati...</td><td>May 28, 2026</td></tr>
<tr><td>shmuelyo</td><td>LLM-93: Add finish rea...</td><td>May 20, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/131?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>