### PR TITLE
LLM-103: Add reviewer approval gate workflow and update CODEOWNERS for uv.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 * @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-dev
 #  ⬆️ Allow Admins and Developers to approve PRs with changes to the repository
 .github/workflows/ @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-devops
-uv.lock @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-devops
-#  ⬆️ Allow Admins and DevOps to approve PRs with changes just to GitHub Actions workflows and uv.lock
+uv.lock @Hirundo-io/hirundo-admins @Hirundo-io/hirundo-devops @Hirundo-io/hirundo-research
+#  ⬆️ Allow Admins and DevOps to approve PRs with changes just to GitHub Actions workflows; allow Researchers to approve uv.lock changes

--- a/.github/workflows/reviewer-approval-gate.yaml
+++ b/.github/workflows/reviewer-approval-gate.yaml
@@ -1,0 +1,99 @@
+name: Reviewer approval gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reviewer-approval-gate:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check approving reviewer comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              },
+            );
+
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              const user = review.user?.login;
+              if (!user) {
+                continue;
+              }
+
+              const current = latestReviewByUser.get(user);
+              if (!current || new Date(review.submitted_at) >= new Date(current.submitted_at)) {
+                latestReviewByUser.set(user, review);
+              }
+            }
+
+            const approvingReviews = [...latestReviewByUser.values()].filter(
+              (review) => review.state === "APPROVED",
+            );
+            const approvingReviewers = new Set(
+              approvingReviews.map((review) => review.user.login),
+            );
+
+            if (approvingReviewers.size === 0) {
+              core.info("No approving reviewers found.");
+              return;
+            }
+
+            if (approvingReviewers.size > 1) {
+              core.info(`Gate passed: ${approvingReviewers.size} reviewers approved this PR.`);
+              return;
+            }
+
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              },
+            );
+            const approvingReviewerComment = reviewComments.find((comment) =>
+              approvingReviewers.has(comment.user?.login),
+            );
+
+            if (approvingReviewerComment) {
+              core.info("Gate passed: the approving reviewer left at least one inline review comment.");
+              return;
+            }
+
+            const [approver] = approvingReviewers;
+            core.setFailed(
+              `Gate failed: ${approver} is the only approving reviewer and did not leave any comments.`,
+            );

--- a/.github/workflows/reviewer-approval-gate.yaml
+++ b/.github/workflows/reviewer-approval-gate.yaml
@@ -4,36 +4,54 @@ on:
   pull_request:
     types:
       - opened
-      - reopened
       - synchronize
+      - reopened
       - ready_for_review
-      - review_requested
-      - review_request_removed
   pull_request_review:
     types:
       - submitted
-      - edited
       - dismissed
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
 
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 jobs:
   reviewer-approval-gate:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Check approving reviewer comments
+      - name: Publish PR review quality status
         uses: actions/github-script@v7
         with:
           script: |
             const {owner, repo} = context.repo;
-            const pull_number = context.payload.pull_request.number;
+            const statusContext = "pr-review-quality-gate";
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const pull_number = context.payload.pull_request?.number;
+
+            if (!Number.isInteger(pull_number) || pull_number < 1) {
+              core.setFailed("Unable to determine pull request number from event payload.");
+              return;
+            }
+
+            let pull;
+            try {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number,
+              });
+              pull = response.data;
+            } catch (error) {
+              core.setFailed(`Unable to evaluate PR #${pull_number}: ${error.message}`);
+              return;
+            }
 
             const reviews = await github.paginate(
               github.rest.pulls.listReviews,
@@ -45,10 +63,15 @@ jobs:
               },
             );
 
+            const isBot = (user) => {
+              const login = user?.login ?? "";
+              return user?.type === "Bot" || login.toLowerCase().endsWith("[bot]");
+            };
+
             const latestReviewByUser = new Map();
             for (const review of reviews) {
               const user = review.user?.login;
-              if (!user) {
+              if (!user || isBot(review.user)) {
                 continue;
               }
 
@@ -65,35 +88,45 @@ jobs:
               approvingReviews.map((review) => review.user.login),
             );
 
+            let state = "success";
+            let description = "Review quality gate passed.";
+
             if (approvingReviewers.size === 0) {
-              core.info("No approving reviewers found.");
-              return;
+              state = "pending";
+              description = "No current human approving reviewers.";
+            } else if (approvingReviewers.size > 1) {
+              description = `${approvingReviewers.size} current approving reviewers.`;
+            } else {
+              const reviewComments = await github.paginate(
+                github.rest.pulls.listReviewComments,
+                {
+                  owner,
+                  repo,
+                  pull_number,
+                  per_page: 100,
+                },
+              );
+              const approvingReviewerComment = reviewComments.find((comment) =>
+                !isBot(comment.user) && approvingReviewers.has(comment.user?.login),
+              );
+
+              if (approvingReviewerComment) {
+                description = "Sole approving reviewer left a file-level review comment.";
+              } else {
+                const [approver] = approvingReviewers;
+                state = "pending";
+                description = `${approver} is the only approver and left no file comments.`;
+              }
             }
 
-            if (approvingReviewers.size > 1) {
-              core.info(`Gate passed: ${approvingReviewers.size} reviewers approved this PR.`);
-              return;
-            }
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: pull.head.sha,
+              state,
+              context: statusContext,
+              description,
+              target_url: runUrl,
+            });
 
-            const reviewComments = await github.paginate(
-              github.rest.pulls.listReviewComments,
-              {
-                owner,
-                repo,
-                pull_number,
-                per_page: 100,
-              },
-            );
-            const approvingReviewerComment = reviewComments.find((comment) =>
-              approvingReviewers.has(comment.user?.login),
-            );
-
-            if (approvingReviewerComment) {
-              core.info("Gate passed: the approving reviewer left at least one inline review comment.");
-              return;
-            }
-
-            const [approver] = approvingReviewers;
-            core.setFailed(
-              `Gate failed: ${approver} is the only approving reviewer and did not leave any comments.`,
-            );
+            core.info(`Published ${statusContext}=${state}: ${description}`);


### PR DESCRIPTION
# User description
## Summary
- Add a GitHub Actions workflow that blocks PRs when there is exactly one approving reviewer and that reviewer did not leave any inline file comments.
- Allow PRs to pass when multiple reviewers approve or when the approving reviewer has at least one file comment.
- Update `CODEOWNERS` so `uv.lock` changes can be approved by `@Hirundo-io/hirundo-research` as well as admins and devops.

## Testing
- YAML syntax validated for the new workflow.
- Embedded GitHub Actions script syntax checked.
- Reviewed the `CODEOWNERS` rule change for `uv.lock`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a reviewer approval gate workflow that monitors pull request approvals, reviewer comments, and publishes the <code>pr-review-quality-gate</code> status to block PRs with a single approving reviewer who left no file comments. Update CODEOWNERS so <code>uv.lock</code> changes can be approved by the research team along with admins and DevOps.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/133?tool=ast&topic=uv.lock+approvers>uv.lock approvers</a>
        </td><td>Allow <code>uv.lock</code> changes to be approved by <code>@Hirundo-io/hirundo-research</code> in addition to admins and DevOps so more reviewers can merge dependency updates.<details><summary>Modified files (1)</summary><ul><li>.github/CODEOWNERS</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Allow researchers to a...</td><td>June 01, 2026</td></tr>
<tr><td>shmuelyo</td><td>updated `CODEOWNERS` (...</td><td>May 20, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/133?tool=ast&topic=Review+quality+gate>Review quality gate</a>
        </td><td>Monitor pull request reviews via the new <code>reviewer-approval-gate</code> workflow to publish the <code>pr-review-quality-gate</code> status, treat multiple approvers or reviewers with comments as passing, and set a pending status when a lone approver lacks file comments.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/reviewer-approval-gate.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Align with `hirundo-co...</td><td>June 01, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/133?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>