### PR TITLE
LLM-104: Fix PR quality gate for merge queue

### DIFF
--- a/.github/workflows/reviewer-approval-gate.yaml
+++ b/.github/workflows/reviewer-approval-gate.yaml
@@ -16,6 +16,9 @@ on:
       - created
       - edited
       - deleted
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read
@@ -33,6 +36,20 @@ jobs:
             const {owner, repo} = context.repo;
             const statusContext = "pr-review-quality-gate";
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            if (context.eventName === "merge_group") {
+              await github.rest.repos.createCommitStatus({
+                owner,
+                repo,
+                sha: context.sha,
+                state: "success",
+                context: statusContext,
+                description: "Review quality gate registered for merge queue.",
+                target_url: runUrl,
+              });
+              return;
+            }
+
             const pull_number = context.payload.pull_request?.number;
 
             if (!Number.isInteger(pull_number) || pull_number < 1) {


### PR DESCRIPTION
# User description
## Summary
- Add `merge_group` support to the PR review quality gate workflow.
- Publish a successful `pr-review-quality-gate` commit status for merge queue runs before PR-specific review logic.
- Keep the existing PR approval behavior unchanged for normal pull request events.

## Testing
- Not run (not requested)
- Verified the workflow YAML parses successfully after the change.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the reviewer-approval-gate workflow publishes <code>pr-review-quality-gate</code> statuses for merge queue runs before PR-specific review logic executes. Keep the existing PR approval behavior unchanged for standard pull request events.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/134?tool=ast&topic=PR+Review+Status>PR Review Status</a>
        </td><td>Maintain the PR review quality gate evaluation that gathers the latest human approvals, inspects comments, and derives the commit status for pull requests.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/reviewer-approval-gate.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Handle merge queue in ...</td><td>June 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/134?tool=ast&topic=Merge+Queue+Gate>Merge Queue Gate</a>
        </td><td>Add <code>merge_group</code> coverage by publishing a successful <code>pr-review-quality-gate</code> status and returning before PR review logic runs when merge queue pushes events.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/reviewer-approval-gate.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Handle merge queue in ...</td><td>June 08, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/134?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>