### PR TITLE
LLM-109: Add Bloom social-bias benchmark presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This toolkit evaluates three classes of behaviors:
     - **bias** (ambiguous) and **unbias** (disambiguated) for: `gender`, `race`, `nationality`, `physical`, `age`, `religion`.
     - Only BBQ provides both ambiguous and disambiguated versions.
   - **UNQOVER**: crowd‑sourced templates probing stereotypes; provides only the ambiguous/bias split for: `religion`, `gender`, `race`, `nationality`.
-  - **Bloom**: synthetic scenario-based age/gender benchmark with paired **bias** and **unbias** splits for: `age`, `gender`.
+  - **Bloom**: synthetic scenario-based benchmark with paired **bias** and **unbias** splits. Currently published for: `age`.
 
 - **Hallucinations (HaluEval, Med‑Hallu)**
   - **HaluEval (halueval)**: general‑domain factuality/consistency checks.
@@ -196,7 +196,7 @@ Per‑model summaries are saved as `results/<model>/summary_full.csv` (full metr
 
 - BBQ: `BBQ: <gender|race|nationality|physical|age|religion> <bias|unbias>`
 - UNQOVER: `UNQOVER: <religion|gender|race|nationality> <bias>`
-- Bloom: `Bloom: <age|gender> <bias|unbias>`
+- Bloom: `Bloom: <age> <bias|unbias>`
 - Hallucination: `halueval` or `medhallu`
 - Prompt Injection: `prompt-injection-purple-llama`
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ All evaluations are compatible with Transformers instruct models. Tested with mu
 
 This toolkit evaluates three classes of behaviors:
 
-- **Bias (BBQ, UNQOVER)**
+- **Bias (BBQ, UNQOVER, Bloom)**
   - **BBQ** (Bias Benchmark for QA): hand‑crafted questions that probe stereotypes across protected dimensions. Supports paired splits:
     - **bias** (ambiguous) and **unbias** (disambiguated) for: `gender`, `race`, `nationality`, `physical`, `age`, `religion`.
     - Only BBQ provides both ambiguous and disambiguated versions.
   - **UNQOVER**: crowd‑sourced templates probing stereotypes; provides only the ambiguous/bias split for: `religion`, `gender`, `race`, `nationality`.
+  - **Bloom**: synthetic scenario-based age/gender benchmark with paired **bias** and **unbias** splits for: `age`, `gender`.
 
 - **Hallucinations (HaluEval, Med‑Hallu)**
   - **HaluEval (halueval)**: general‑domain factuality/consistency checks.
@@ -32,6 +33,7 @@ Dataset identifiers:
 
 - BBQ: `hirundo-io/bbq-<bias_type>-<bias|unbias>-free-text`
 - UNQOVER: `unqover/unqover-<bias_type>-bias-free-text`
+- Bloom: `hirundo-io/bloom-<bias_type>-<bias|unbias>-free-text`
 - HaluEval: `hirundo-io/halueval`
 - Med‑Hallu: `hirundo-io/medhallu`
 - Prompt Injection (Purple Llama): `hirundo-io/prompt-injection-purple-llama`
@@ -40,6 +42,7 @@ How to select behaviors in the CLI (`evaluate.py`):
 
 - BBQ: `--behavior bias:<bias_type>` or `--behavior unbias:<bias_type>`
 - UNQOVER: `--behavior unqover:bias:<bias_type>`
+- Bloom: `--behavior bloom:bias:<bias_type>` or `--behavior bloom:unbias:<bias_type>`
 - Hallucinations:
   - HaluEval: `--behavior hallu`
   - Med‑Hallu: `--behavior hallu-med`
@@ -51,6 +54,7 @@ You can also run across all supported bias types using `all`:
 - BBQ (all ambiguous/bias splits): `--behavior bias:all`
 - BBQ (all unambiguous/unbias splits): `--behavior unbias:all`
 - UNQOVER (all bias splits): `--behavior unqover:bias:all`
+- Bloom (all bias or unbias splits): `--behavior bloom:bias:all` or `--behavior bloom:unbias:all`
 ---
 
 ## Requirements
@@ -119,6 +123,16 @@ llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct bias:all
 llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct unqover:bias:all
 ```
 
+- **Bloom (bias)** — evaluate a model on Bloom scenario-based bias:
+```bash
+llm-behavior-eval google/gemma-2b-it bloom:bias:age
+```
+
+- **Bloom (unbias)** — evaluate a model on Bloom disambiguated scenarios:
+```bash
+llm-behavior-eval google/gemma-2b-it bloom:unbias:age
+```
+
 - **Hallucination (general)** — HaluEval free‑text:
 ```bash
 llm-behavior-eval google/gemma-2b-it hallu
@@ -182,6 +196,7 @@ Per‑model summaries are saved as `results/<model>/summary_full.csv` (full metr
 
 - BBQ: `BBQ: <gender|race|nationality|physical|age|religion> <bias|unbias>`
 - UNQOVER: `UNQOVER: <religion|gender|race|nationality> <bias>`
+- Bloom: `Bloom: <age|gender> <bias|unbias>`
 - Hallucination: `halueval` or `medhallu`
 - Prompt Injection: `prompt-injection-purple-llama`
 

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -14,7 +14,12 @@ from llm_behavior_eval.evaluation_utils.dataset_config import (
     DatasetConfig,
     PreprocessConfig,
 )
-from llm_behavior_eval.evaluation_utils.enums import DatasetType
+from llm_behavior_eval.evaluation_utils.enums import (
+    BBQ_BIAS_TYPES,
+    BLOOM_BIAS_TYPES,
+    UNQOVER_BIAS_TYPES,
+    DatasetType,
+)
 from llm_behavior_eval.evaluation_utils.eval_config import EvaluationConfig
 from llm_behavior_eval.evaluation_utils.evaluate_factory import EvaluateFactory
 from llm_behavior_eval.evaluation_utils.sampling_config import SamplingConfig
@@ -27,6 +32,20 @@ from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
 torch.set_float32_matmul_precision("high")
 
 BIAS_KINDS = {"bias", "unbias"}
+THREE_PART_BIAS_BEHAVIORS: dict[str, tuple[set[str], set[str], str, str]] = {
+    "unqover": (
+        UNQOVER_BIAS_TYPES,
+        {"bias"},
+        "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
+        "UNQOVER",
+    ),
+    "bloom": (
+        BLOOM_BIAS_TYPES,
+        BIAS_KINDS,
+        "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
+        "BLOOM",
+    ),
+}
 HALUEVAL_ALIAS = {"hallu", "hallucination"}
 MEDHALLU_ALIAS = {"hallu-med", "hallucination-med"}
 INJECTION_ALIAS = {"prompt-injection"}
@@ -74,27 +93,6 @@ def _resolve_bias_behavior(
     if bias_type not in allowed_types:
         raise ValueError(f"{support_label} supports: {allowed_with_all}")
     return [f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"]
-
-
-def _skip_dataset_if_not_found(exc: Exception, file_path: str) -> None:
-    """Log and swallow a missing-dataset error, re-raising anything else.
-
-    Args:
-        exc: Exception raised while loading or evaluating a dataset.
-        file_path: Identifier of the dataset being processed, used for logging.
-
-    Raises:
-        Exception: Re-raises ``exc`` when it is not a missing-dataset error.
-    """
-    if not (
-        isinstance(exc, RuntimeError) and str(exc).startswith("Failed to load dataset ")
-    ):
-        raise exc
-    logging.warning(
-        "Skipping dataset %s because it could not be loaded: %s",
-        file_path,
-        exc,
-    )
 
 
 def _default_results_dir() -> Path:
@@ -149,7 +147,6 @@ def _behavior_presets(behavior: str) -> list[str]:
         kind, bias_type = behavior_parts
         if kind not in BIAS_KINDS:
             raise ValueError("For BBQ use 'bias:<bias_type>' or 'unbias:<bias_type>'")
-        from llm_behavior_eval.evaluation_utils.enums import BBQ_BIAS_TYPES
 
         if bias_type == "all":
             return [
@@ -163,30 +160,11 @@ def _behavior_presets(behavior: str) -> list[str]:
 
     if len(behavior_parts) == 3:
         prefix, kind, bias_type = behavior_parts
-        from llm_behavior_eval.evaluation_utils.enums import (
-            BLOOM_BIAS_TYPES,
-            UNQOVER_BIAS_TYPES,
-        )
-
-        three_part_bias_behaviors = {
-            "unqover": (
-                UNQOVER_BIAS_TYPES,
-                {"bias"},
-                "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
-                "UNQOVER",
-            ),
-            "bloom": (
-                BLOOM_BIAS_TYPES,
-                BIAS_KINDS,
-                "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
-                "BLOOM",
-            ),
-        }
-        if prefix not in three_part_bias_behaviors:
+        if prefix not in THREE_PART_BIAS_BEHAVIORS:
             raise ValueError(BEHAVIOR_PRESET_ERROR)
 
         allowed_types, allowed_kinds, kind_error, support_label = (
-            three_part_bias_behaviors[prefix]
+            THREE_PART_BIAS_BEHAVIORS[prefix]
         )
         return _resolve_bias_behavior(
             prefix,
@@ -702,25 +680,13 @@ def main(
                     seed=seed,
                 )
                 if evaluator is None:
-                    try:
-                        evaluator = EvaluateFactory.create_evaluator(
-                            eval_config, dataset_config
-                        )
-                    except Exception as exc:
-                        _skip_dataset_if_not_found(exc, file_path)
-                        continue
+                    evaluator = EvaluateFactory.create_evaluator(
+                        eval_config, dataset_config
+                    )
                 else:
-                    try:
-                        evaluator.update_dataset_config(dataset_config)
-                    except Exception as exc:
-                        _skip_dataset_if_not_found(exc, file_path)
-                        continue
+                    evaluator.update_dataset_config(dataset_config)
 
-                try:
-                    generation_records = evaluator.generate()
-                except Exception as exc:
-                    _skip_dataset_if_not_found(exc, file_path)
-                    continue
+                generation_records = evaluator.generate()
 
                 dataset_configs.append(dataset_config)
                 dataset_file_paths.append(file_path)
@@ -740,11 +706,7 @@ def main(
                 generation_lists, dataset_configs, dataset_file_paths, strict=True
             ):
                 logging.info("Grading %s with %s", file_path, judge_path_or_repo_id)
-                try:
-                    evaluator.update_dataset_config(dataset_config)
-                except Exception as exc:
-                    _skip_dataset_if_not_found(exc, file_path)
-                    continue
+                evaluator.update_dataset_config(dataset_config)
                 with evaluator.dataset_mlflow_run():
                     evaluator.grade(generations, judge)
         evaluation_error = False

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -160,32 +160,43 @@ def _behavior_presets(behavior: str) -> list[str]:
             raise ValueError(f"BBQ supports: {allowed}")
         return [f"hirundo-io/bbq-{bias_type}-{kind}-free-text"]
 
-    if len(behavior_parts) == 3 and behavior_parts[0] == "unqover":
-        _, kind, bias_type = behavior_parts
-        from llm_behavior_eval.evaluation_utils.enums import UNQOVER_BIAS_TYPES
-
-        return _resolve_bias_behavior(
-            "unqover",
-            kind,
-            bias_type,
+    if len(behavior_parts) == 3:
+        prefix, kind, bias_type = behavior_parts
+        from llm_behavior_eval.evaluation_utils.enums import (
+            BLOOM_BIAS_TYPES,
             UNQOVER_BIAS_TYPES,
-            {"bias"},
-            "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
-            "UNQOVER",
         )
 
-    if len(behavior_parts) == 3 and behavior_parts[0] == "bloom":
-        _, kind, bias_type = behavior_parts
-        from llm_behavior_eval.evaluation_utils.enums import BLOOM_BIAS_TYPES
+        three_part_bias_behaviors = {
+            "unqover": (
+                UNQOVER_BIAS_TYPES,
+                {"bias"},
+                "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
+                "UNQOVER",
+            ),
+            "bloom": (
+                BLOOM_BIAS_TYPES,
+                BIAS_KINDS,
+                "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
+                "BLOOM",
+            ),
+        }
+        if prefix not in three_part_bias_behaviors:
+            raise ValueError(
+                "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
+            )
 
+        allowed_types, allowed_kinds, kind_error, support_label = (
+            three_part_bias_behaviors[prefix]
+        )
         return _resolve_bias_behavior(
-            "bloom",
+            prefix,
             kind,
             bias_type,
-            BLOOM_BIAS_TYPES,
-            BIAS_KINDS,
-            "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
-            "BLOOM",
+            allowed_types,
+            allowed_kinds,
+            kind_error,
+            support_label,
         )
 
     raise ValueError(

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -67,8 +67,7 @@ def _resolve_bias_behavior(
     allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
     if bias_type == "all":
         return [
-            f"hirundo-io/{prefix}-{bt}-{kind}-free-text"
-            for bt in sorted(allowed_types)
+            f"hirundo-io/{prefix}-{bt}-{kind}-free-text" for bt in sorted(allowed_types)
         ]
 
     if bias_type not in allowed_types:

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -79,6 +79,7 @@ def _behavior_presets(behavior: str) -> list[str]:
     New formats:
     - BBQ: "bias:<bias_type>" or "unbias:<bias_type>"
     - UNQOVER: "unqover:bias:<bias_type>" (UNQOVER does not support 'unbias')
+    - Bloom: "bloom:bias:<bias_type>" or "bloom:unbias:<bias_type>"
     - Hallucinations: "hallu" or "hallu-med"
     - Prompt injection: "prompt-injection"
     """
@@ -96,6 +97,8 @@ def _behavior_presets(behavior: str) -> list[str]:
     # [kind, bias_type] for BBQ, where kind in {bias, unbias}
     #   - bias_type can be a concrete type or 'all'
     # ["unqover", kind, bias_type] for UNQOVER (kind must be 'bias')
+    #   - bias_type can be a concrete type or 'all'
+    # ["bloom", kind, bias_type] for Bloom, where kind in {bias, unbias}
     #   - bias_type can be a concrete type or 'all'
     if len(behavior_parts) == 2:
         kind, bias_type = behavior_parts
@@ -131,8 +134,26 @@ def _behavior_presets(behavior: str) -> list[str]:
             raise ValueError(f"UNQOVER supports: {allowed}")
         return [f"hirundo-io/unqover-{bias_type}-{kind}-free-text"]
 
+    if len(behavior_parts) == 3 and behavior_parts[0] == "bloom":
+        _, kind, bias_type = behavior_parts
+        if kind not in BIAS_KINDS:
+            raise ValueError(
+                "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'"
+            )
+        from llm_behavior_eval.evaluation_utils.enums import BLOOM_BIAS_TYPES
+
+        if bias_type == "all":
+            return [
+                f"hirundo-io/bloom-{bt}-{kind}-free-text"
+                for bt in sorted(BLOOM_BIAS_TYPES)
+            ]
+        if bias_type not in BLOOM_BIAS_TYPES:
+            allowed = ", ".join(sorted(list(BLOOM_BIAS_TYPES)) + ["all"])
+            raise ValueError(f"BLOOM supports: {allowed}")
+        return [f"hirundo-io/bloom-{bias_type}-{kind}-free-text"]
+
     raise ValueError(
-        "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
+        "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
     )
 
 
@@ -146,7 +167,7 @@ def main(
     behavior: Annotated[
         str,
         typer.Argument(
-            help="Behavior preset(s). Can be comma-separated for multiple behaviors. BBQ: 'bias:<type>' or 'unbias:<type>'; UNQOVER: 'unqover:bias:<type>'; Hallucination: 'hallu' | 'hallu-med'; Prompt injection: 'prompt-injection'"
+            help="Behavior preset(s). Can be comma-separated for multiple behaviors. BBQ: 'bias:<type>' or 'unbias:<type>'; UNQOVER: 'unqover:bias:<type>'; Bloom: 'bloom:bias:<type|all>' or 'bloom:unbias:<type|all>'; Hallucination: 'hallu' | 'hallu-med'; Prompt injection: 'prompt-injection'"
         ),
     ],
     output_dir: Annotated[

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -30,6 +30,7 @@ BIAS_KINDS = {"bias", "unbias"}
 HALUEVAL_ALIAS = {"hallu", "hallucination"}
 MEDHALLU_ALIAS = {"hallu-med", "hallucination-med"}
 INJECTION_ALIAS = {"prompt-injection"}
+BEHAVIOR_PRESET_ERROR = "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
 TRUSTED_MODEL_PROVIDERS = {
     "hirundo-io",
     "nvidia",
@@ -182,9 +183,7 @@ def _behavior_presets(behavior: str) -> list[str]:
             ),
         }
         if prefix not in three_part_bias_behaviors:
-            raise ValueError(
-                "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
-            )
+            raise ValueError(BEHAVIOR_PRESET_ERROR)
 
         allowed_types, allowed_kinds, kind_error, support_label = (
             three_part_bias_behaviors[prefix]
@@ -199,9 +198,7 @@ def _behavior_presets(behavior: str) -> list[str]:
             support_label,
         )
 
-    raise ValueError(
-        "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
-    )
+    raise ValueError(BEHAVIOR_PRESET_ERROR)
 
 
 def main(

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -15,9 +15,13 @@ from llm_behavior_eval.evaluation_utils.dataset_config import (
     PreprocessConfig,
 )
 from llm_behavior_eval.evaluation_utils.enums import (
-    BBQ_BIAS_TYPES,
-    BLOOM_BIAS_TYPES,
-    UNQOVER_BIAS_TYPES,
+    BBQ_BIAS_BEHAVIOR,
+    BEHAVIOR_PRESET_ERROR,
+    HALUEVAL_ALIAS,
+    INJECTION_ALIAS,
+    MEDHALLU_ALIAS,
+    THREE_PART_BIAS_BEHAVIORS,
+    TRUSTED_MODEL_PROVIDERS,
     DatasetType,
 )
 from llm_behavior_eval.evaluation_utils.eval_config import EvaluationConfig
@@ -31,39 +35,6 @@ from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
 
 torch.set_float32_matmul_precision("high")
 
-BIAS_KINDS = {"bias", "unbias"}
-BBQ_BIAS_BEHAVIOR = (
-    BBQ_BIAS_TYPES,
-    BIAS_KINDS,
-    "For BBQ use 'bias:<bias_type>' or 'unbias:<bias_type>'",
-    "BBQ",
-)
-THREE_PART_BIAS_BEHAVIORS: dict[str, tuple[set[str], set[str], str, str]] = {
-    "unqover": (
-        UNQOVER_BIAS_TYPES,
-        {"bias"},
-        "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
-        "UNQOVER",
-    ),
-    "bloom": (
-        BLOOM_BIAS_TYPES,
-        BIAS_KINDS,
-        "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
-        "BLOOM",
-    ),
-}
-HALUEVAL_ALIAS = {"hallu", "hallucination"}
-MEDHALLU_ALIAS = {"hallu-med", "hallucination-med"}
-INJECTION_ALIAS = {"prompt-injection"}
-BEHAVIOR_PRESET_ERROR = "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
-TRUSTED_MODEL_PROVIDERS = {
-    "hirundo-io",
-    "nvidia",
-    "meta-llama",
-    "google",
-    "aisingapore",
-    "LGAI-EXAONE",
-}
 DEFAULT_MAX_SAMPLES = EvaluationConfig.model_fields["max_samples"].default
 DEFAULT_BATCH_SIZE = EvaluationConfig.model_fields["batch_size"].default
 DEFAULT_USE_4BIT = EvaluationConfig.model_fields["use_4bit"].default
@@ -700,7 +671,10 @@ def main(
                 evaluator.free_test_model()
 
         if evaluator is None:
-            logging.warning("No datasets were evaluated.")
+            logging.warning(
+                "Evaluator could not be created; no datasets were evaluated. "
+                "See logs above for details."
+            )
             evaluation_error = False
             return
 

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -32,6 +32,12 @@ from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
 torch.set_float32_matmul_precision("high")
 
 BIAS_KINDS = {"bias", "unbias"}
+BBQ_BIAS_BEHAVIOR = (
+    BBQ_BIAS_TYPES,
+    BIAS_KINDS,
+    "For BBQ use 'bias:<bias_type>' or 'unbias:<bias_type>'",
+    "BBQ",
+)
 THREE_PART_BIAS_BEHAVIORS: dict[str, tuple[set[str], set[str], str, str]] = {
     "unqover": (
         UNQOVER_BIAS_TYPES,
@@ -145,18 +151,16 @@ def _behavior_presets(behavior: str) -> list[str]:
     #   - bias_type can be a concrete type or 'all'
     if len(behavior_parts) == 2:
         kind, bias_type = behavior_parts
-        if kind not in BIAS_KINDS:
-            raise ValueError("For BBQ use 'bias:<bias_type>' or 'unbias:<bias_type>'")
-
-        if bias_type == "all":
-            return [
-                f"hirundo-io/bbq-{bias_type}-{kind}-free-text"
-                for bias_type in sorted(BBQ_BIAS_TYPES)
-            ]
-        if bias_type not in BBQ_BIAS_TYPES:
-            allowed = ", ".join(sorted(list(BBQ_BIAS_TYPES)) + ["all"])
-            raise ValueError(f"BBQ supports: {allowed}")
-        return [f"hirundo-io/bbq-{bias_type}-{kind}-free-text"]
+        allowed_types, allowed_kinds, kind_error, support_label = BBQ_BIAS_BEHAVIOR
+        return _resolve_bias_behavior(
+            "bbq",
+            kind,
+            bias_type,
+            allowed_types,
+            allowed_kinds,
+            kind_error,
+            support_label,
+        )
 
     if len(behavior_parts) == 3:
         prefix, kind, bias_type = behavior_parts

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -52,6 +52,35 @@ DEFAULT_TOP_K = SamplingConfig.model_fields["top_k"].default
 DEFAULT_MAX_LORA_RANK = VllmConfig.model_fields["max_lora_rank"].default
 
 
+def _resolve_bias_behavior(
+    prefix: str,
+    kind: str,
+    bias_type: str,
+    allowed_types: set[str],
+    allowed_kinds: set[str],
+    kind_error: str,
+    support_label: str,
+) -> list[str]:
+    if kind not in allowed_kinds:
+        raise ValueError(kind_error)
+
+    allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
+    if bias_type == "all":
+        return [
+            f"hirundo-io/{prefix}-{bt}-{kind}-free-text" for bt in sorted(allowed_types)
+        ]
+
+    if bias_type not in allowed_types:
+        raise ValueError(f"{support_label} supports: {allowed_with_all}")
+    return [f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"]
+
+
+def _is_dataset_not_found_error(exc: Exception) -> bool:
+    return isinstance(exc, RuntimeError) and str(exc).startswith(
+        "Failed to load dataset "
+    )
+
+
 def _default_results_dir() -> Path:
     if os.name == "nt":
         base_dir = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
@@ -118,39 +147,31 @@ def _behavior_presets(behavior: str) -> list[str]:
 
     if len(behavior_parts) == 3 and behavior_parts[0] == "unqover":
         _, kind, bias_type = behavior_parts
-        if kind != "bias":
-            raise ValueError(
-                "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)"
-            )
         from llm_behavior_eval.evaluation_utils.enums import UNQOVER_BIAS_TYPES
 
-        if bias_type == "all":
-            return [
-                f"hirundo-io/unqover-{bt}-{kind}-free-text"
-                for bt in sorted(UNQOVER_BIAS_TYPES)
-            ]
-        if bias_type not in UNQOVER_BIAS_TYPES:
-            allowed = ", ".join(sorted(list(UNQOVER_BIAS_TYPES)) + ["all"])
-            raise ValueError(f"UNQOVER supports: {allowed}")
-        return [f"hirundo-io/unqover-{bias_type}-{kind}-free-text"]
+        return _resolve_bias_behavior(
+            "unqover",
+            kind,
+            bias_type,
+            UNQOVER_BIAS_TYPES,
+            {"bias"},
+            "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
+            "UNQOVER",
+        )
 
     if len(behavior_parts) == 3 and behavior_parts[0] == "bloom":
         _, kind, bias_type = behavior_parts
-        if kind not in BIAS_KINDS:
-            raise ValueError(
-                "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'"
-            )
         from llm_behavior_eval.evaluation_utils.enums import BLOOM_BIAS_TYPES
 
-        if bias_type == "all":
-            return [
-                f"hirundo-io/bloom-{bt}-{kind}-free-text"
-                for bt in sorted(BLOOM_BIAS_TYPES)
-            ]
-        if bias_type not in BLOOM_BIAS_TYPES:
-            allowed = ", ".join(sorted(list(BLOOM_BIAS_TYPES)) + ["all"])
-            raise ValueError(f"BLOOM supports: {allowed}")
-        return [f"hirundo-io/bloom-{bias_type}-{kind}-free-text"]
+        return _resolve_bias_behavior(
+            "bloom",
+            kind,
+            bias_type,
+            BLOOM_BIAS_TYPES,
+            BIAS_KINDS,
+            "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
+            "BLOOM",
+        )
 
     raise ValueError(
         "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
@@ -635,6 +656,7 @@ def main(
     evaluator = None
     generation_lists = []
     dataset_configs = []
+    dataset_file_paths = []
     evaluation_error = True
     try:
         # generation loop
@@ -657,29 +679,73 @@ def main(
                     seed=seed,
                 )
                 if evaluator is None:
-                    evaluator = EvaluateFactory.create_evaluator(
-                        eval_config, dataset_config
-                    )
+                    try:
+                        evaluator = EvaluateFactory.create_evaluator(
+                            eval_config, dataset_config
+                        )
+                    except Exception as exc:
+                        if not _is_dataset_not_found_error(exc):
+                            raise
+                        logging.warning(
+                            "Skipping dataset %s because it could not be loaded: %s",
+                            file_path,
+                            exc,
+                        )
+                        continue
                 else:
-                    evaluator.update_dataset_config(dataset_config)
+                    try:
+                        evaluator.update_dataset_config(dataset_config)
+                    except Exception as exc:
+                        if not _is_dataset_not_found_error(exc):
+                            raise
+                        logging.warning(
+                            "Skipping dataset %s because it could not be loaded: %s",
+                            file_path,
+                            exc,
+                        )
+                        continue
+
+                try:
+                    generation_records = evaluator.generate()
+                except Exception as exc:
+                    if not _is_dataset_not_found_error(exc):
+                        raise
+                    logging.warning(
+                        "Skipping dataset %s because it could not be loaded: %s",
+                        file_path,
+                        exc,
+                    )
+                    continue
 
                 dataset_configs.append(dataset_config)
-                generation_lists.append(evaluator.generate())
+                dataset_file_paths.append(file_path)
+                generation_lists.append(generation_records)
         finally:
             if evaluator is not None:
                 evaluator.free_test_model()
 
         if evaluator is None:
-            # Type-checking hint
-            raise ValueError("Evaluator does not exist.")
+            logging.warning("No datasets were evaluated.")
+            evaluation_error = False
+            return
 
         # Grading loop
         with evaluator.get_grading_context() as judge:
             for generations, dataset_config, file_path in zip(
-                generation_lists, dataset_configs, file_paths, strict=True
+                generation_lists, dataset_configs, dataset_file_paths, strict=True
             ):
                 logging.info("Grading %s with %s", file_path, judge_path_or_repo_id)
-                evaluator.update_dataset_config(dataset_config)
+                try:
+                    evaluator.update_dataset_config(dataset_config)
+                except Exception as exc:
+                    if not _is_dataset_not_found_error(exc):
+                        raise
+                    logging.warning(
+                        "Skipping dataset %s because it could not be loaded: %s",
+                        file_path,
+                        exc,
+                    )
+                    continue
                 with evaluator.dataset_mlflow_run():
                     evaluator.grade(generations, judge)
         evaluation_error = False

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -52,6 +52,36 @@ DEFAULT_TOP_K = SamplingConfig.model_fields["top_k"].default
 DEFAULT_MAX_LORA_RANK = VllmConfig.model_fields["max_lora_rank"].default
 
 
+def _resolve_bias_behavior(
+    prefix: str,
+    kind: str,
+    bias_type: str,
+    allowed_types: set[str],
+    allowed_kinds: set[str],
+    kind_error: str,
+    support_label: str,
+) -> list[str]:
+    if kind not in allowed_kinds:
+        raise ValueError(kind_error)
+
+    allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
+    if bias_type == "all":
+        return [
+            f"hirundo-io/{prefix}-{bt}-{kind}-free-text"
+            for bt in sorted(allowed_types)
+        ]
+
+    if bias_type not in allowed_types:
+        raise ValueError(f"{support_label} supports: {allowed_with_all}")
+    return [f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"]
+
+
+def _is_dataset_not_found_error(exc: Exception) -> bool:
+    return isinstance(exc, RuntimeError) and str(exc).startswith(
+        "Failed to load dataset "
+    )
+
+
 def _default_results_dir() -> Path:
     if os.name == "nt":
         base_dir = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
@@ -118,39 +148,31 @@ def _behavior_presets(behavior: str) -> list[str]:
 
     if len(behavior_parts) == 3 and behavior_parts[0] == "unqover":
         _, kind, bias_type = behavior_parts
-        if kind != "bias":
-            raise ValueError(
-                "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)"
-            )
         from llm_behavior_eval.evaluation_utils.enums import UNQOVER_BIAS_TYPES
 
-        if bias_type == "all":
-            return [
-                f"hirundo-io/unqover-{bt}-{kind}-free-text"
-                for bt in sorted(UNQOVER_BIAS_TYPES)
-            ]
-        if bias_type not in UNQOVER_BIAS_TYPES:
-            allowed = ", ".join(sorted(list(UNQOVER_BIAS_TYPES)) + ["all"])
-            raise ValueError(f"UNQOVER supports: {allowed}")
-        return [f"hirundo-io/unqover-{bias_type}-{kind}-free-text"]
+        return _resolve_bias_behavior(
+            "unqover",
+            kind,
+            bias_type,
+            UNQOVER_BIAS_TYPES,
+            {"bias"},
+            "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
+            "UNQOVER",
+        )
 
     if len(behavior_parts) == 3 and behavior_parts[0] == "bloom":
         _, kind, bias_type = behavior_parts
-        if kind not in BIAS_KINDS:
-            raise ValueError(
-                "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'"
-            )
         from llm_behavior_eval.evaluation_utils.enums import BLOOM_BIAS_TYPES
 
-        if bias_type == "all":
-            return [
-                f"hirundo-io/bloom-{bt}-{kind}-free-text"
-                for bt in sorted(BLOOM_BIAS_TYPES)
-            ]
-        if bias_type not in BLOOM_BIAS_TYPES:
-            allowed = ", ".join(sorted(list(BLOOM_BIAS_TYPES)) + ["all"])
-            raise ValueError(f"BLOOM supports: {allowed}")
-        return [f"hirundo-io/bloom-{bias_type}-{kind}-free-text"]
+        return _resolve_bias_behavior(
+            "bloom",
+            kind,
+            bias_type,
+            BLOOM_BIAS_TYPES,
+            BIAS_KINDS,
+            "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
+            "BLOOM",
+        )
 
     raise ValueError(
         "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
@@ -635,6 +657,7 @@ def main(
     evaluator = None
     generation_lists = []
     dataset_configs = []
+    dataset_file_paths = []
     evaluation_error = True
     try:
         # generation loop
@@ -657,29 +680,73 @@ def main(
                     seed=seed,
                 )
                 if evaluator is None:
-                    evaluator = EvaluateFactory.create_evaluator(
-                        eval_config, dataset_config
-                    )
+                    try:
+                        evaluator = EvaluateFactory.create_evaluator(
+                            eval_config, dataset_config
+                        )
+                    except Exception as exc:
+                        if not _is_dataset_not_found_error(exc):
+                            raise
+                        logging.warning(
+                            "Skipping dataset %s because it could not be loaded: %s",
+                            file_path,
+                            exc,
+                        )
+                        continue
                 else:
-                    evaluator.update_dataset_config(dataset_config)
+                    try:
+                        evaluator.update_dataset_config(dataset_config)
+                    except Exception as exc:
+                        if not _is_dataset_not_found_error(exc):
+                            raise
+                        logging.warning(
+                            "Skipping dataset %s because it could not be loaded: %s",
+                            file_path,
+                            exc,
+                        )
+                        continue
+
+                try:
+                    generation_records = evaluator.generate()
+                except Exception as exc:
+                    if not _is_dataset_not_found_error(exc):
+                        raise
+                    logging.warning(
+                        "Skipping dataset %s because it could not be loaded: %s",
+                        file_path,
+                        exc,
+                    )
+                    continue
 
                 dataset_configs.append(dataset_config)
-                generation_lists.append(evaluator.generate())
+                dataset_file_paths.append(file_path)
+                generation_lists.append(generation_records)
         finally:
             if evaluator is not None:
                 evaluator.free_test_model()
 
         if evaluator is None:
-            # Type-checking hint
-            raise ValueError("Evaluator does not exist.")
+            logging.warning("No datasets were evaluated.")
+            evaluation_error = False
+            return
 
         # Grading loop
         with evaluator.get_grading_context() as judge:
             for generations, dataset_config, file_path in zip(
-                generation_lists, dataset_configs, file_paths, strict=True
+                generation_lists, dataset_configs, dataset_file_paths, strict=True
             ):
                 logging.info("Grading %s with %s", file_path, judge_path_or_repo_id)
-                evaluator.update_dataset_config(dataset_config)
+                try:
+                    evaluator.update_dataset_config(dataset_config)
+                except Exception as exc:
+                    if not _is_dataset_not_found_error(exc):
+                        raise
+                    logging.warning(
+                        "Skipping dataset %s because it could not be loaded: %s",
+                        file_path,
+                        exc,
+                    )
+                    continue
                 with evaluator.dataset_mlflow_run():
                     evaluator.grade(generations, judge)
         evaluation_error = False

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -82,6 +82,25 @@ def _is_dataset_not_found_error(exc: Exception) -> bool:
     )
 
 
+def _skip_dataset_if_not_found(exc: Exception, file_path: str) -> None:
+    """Log and swallow a missing-dataset error, re-raising anything else.
+
+    Args:
+        exc: Exception raised while loading or evaluating a dataset.
+        file_path: Identifier of the dataset being processed, used for logging.
+
+    Raises:
+        Exception: Re-raises ``exc`` when it is not a missing-dataset error.
+    """
+    if not _is_dataset_not_found_error(exc):
+        raise exc
+    logging.warning(
+        "Skipping dataset %s because it could not be loaded: %s",
+        file_path,
+        exc,
+    )
+
+
 def _default_results_dir() -> Path:
     if os.name == "nt":
         base_dir = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
@@ -685,37 +704,19 @@ def main(
                             eval_config, dataset_config
                         )
                     except Exception as exc:
-                        if not _is_dataset_not_found_error(exc):
-                            raise
-                        logging.warning(
-                            "Skipping dataset %s because it could not be loaded: %s",
-                            file_path,
-                            exc,
-                        )
+                        _skip_dataset_if_not_found(exc, file_path)
                         continue
                 else:
                     try:
                         evaluator.update_dataset_config(dataset_config)
                     except Exception as exc:
-                        if not _is_dataset_not_found_error(exc):
-                            raise
-                        logging.warning(
-                            "Skipping dataset %s because it could not be loaded: %s",
-                            file_path,
-                            exc,
-                        )
+                        _skip_dataset_if_not_found(exc, file_path)
                         continue
 
                 try:
                     generation_records = evaluator.generate()
                 except Exception as exc:
-                    if not _is_dataset_not_found_error(exc):
-                        raise
-                    logging.warning(
-                        "Skipping dataset %s because it could not be loaded: %s",
-                        file_path,
-                        exc,
-                    )
+                    _skip_dataset_if_not_found(exc, file_path)
                     continue
 
                 dataset_configs.append(dataset_config)
@@ -739,13 +740,7 @@ def main(
                 try:
                     evaluator.update_dataset_config(dataset_config)
                 except Exception as exc:
-                    if not _is_dataset_not_found_error(exc):
-                        raise
-                    logging.warning(
-                        "Skipping dataset %s because it could not be loaded: %s",
-                        file_path,
-                        exc,
-                    )
+                    _skip_dataset_if_not_found(exc, file_path)
                     continue
                 with evaluator.dataset_mlflow_run():
                     evaluator.grade(generations, judge)

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -10,10 +10,6 @@ import typer
 
 os.environ["TORCHDYNAMO_DISABLE"] = "1"
 
-from llm_behavior_eval.evaluation_utils.base_evaluator import (
-    active_mlflow_run_id,
-    end_active_mlflow_run,
-)
 from llm_behavior_eval.evaluation_utils.dataset_config import (
     DatasetConfig,
     PreprocessConfig,
@@ -79,12 +75,6 @@ def _resolve_bias_behavior(
     return [f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"]
 
 
-def _is_dataset_not_found_error(exc: Exception) -> bool:
-    return isinstance(exc, RuntimeError) and str(exc).startswith(
-        "Failed to load dataset "
-    )
-
-
 def _skip_dataset_if_not_found(exc: Exception, file_path: str) -> None:
     """Log and swallow a missing-dataset error, re-raising anything else.
 
@@ -95,7 +85,9 @@ def _skip_dataset_if_not_found(exc: Exception, file_path: str) -> None:
     Raises:
         Exception: Re-raises ``exc`` when it is not a missing-dataset error.
     """
-    if not _is_dataset_not_found_error(exc):
+    if not (
+        isinstance(exc, RuntimeError) and str(exc).startswith("Failed to load dataset ")
+    ):
         raise exc
     logging.warning(
         "Skipping dataset %s because it could not be loaded: %s",
@@ -702,18 +694,11 @@ def main(
                     seed=seed,
                 )
                 if evaluator is None:
-                    initial_mlflow_run_id = active_mlflow_run_id()
                     try:
                         evaluator = EvaluateFactory.create_evaluator(
                             eval_config, dataset_config
                         )
                     except Exception as exc:
-                        active_run_id = active_mlflow_run_id()
-                        if (
-                            active_run_id is not None
-                            and active_run_id != initial_mlflow_run_id
-                        ):
-                            end_active_mlflow_run(error=True)
                         _skip_dataset_if_not_found(exc, file_path)
                         continue
                 else:

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -10,6 +10,10 @@ import typer
 
 os.environ["TORCHDYNAMO_DISABLE"] = "1"
 
+from llm_behavior_eval.evaluation_utils.base_evaluator import (
+    active_mlflow_run_id,
+    end_active_mlflow_run,
+)
 from llm_behavior_eval.evaluation_utils.dataset_config import (
     DatasetConfig,
     PreprocessConfig,
@@ -698,11 +702,18 @@ def main(
                     seed=seed,
                 )
                 if evaluator is None:
+                    initial_mlflow_run_id = active_mlflow_run_id()
                     try:
                         evaluator = EvaluateFactory.create_evaluator(
                             eval_config, dataset_config
                         )
                     except Exception as exc:
+                        active_run_id = active_mlflow_run_id()
+                        if (
+                            active_run_id is not None
+                            and active_run_id != initial_mlflow_run_id
+                        ):
+                            end_active_mlflow_run(error=True)
                         _skip_dataset_if_not_found(exc, file_path)
                         continue
                 else:

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -171,10 +171,6 @@ class BaseEvaluator(ABC):
             )
         self.tokenizer = self.eval_engine.tokenizer
         self.trust_remote_code = self.eval_config.trust_remote_code
-        # Must be set BEFORE prepare_dataloader(): the dataset is tokenized and
-        # padded to max_length inside prepare_dataloader(), and decoder-only
-        # generation requires left-padding to produce correct outputs. Setting
-        # this afterwards leaves the already-tokenized inputs right-padded.
         self.tokenizer.padding_side = "left"
         self.prepare_dataloader()
         self.ensure_test_model_ready = self.eval_engine.ensure_test_model_ready

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -161,9 +161,13 @@ class BaseEvaluator(ABC):
             )
         self.tokenizer = self.eval_engine.tokenizer
         self.trust_remote_code = self.eval_config.trust_remote_code
+        # Must be set BEFORE prepare_dataloader(): the dataset is tokenized and
+        # padded to max_length inside prepare_dataloader(), and decoder-only
+        # generation requires left-padding to produce correct outputs. Setting
+        # this afterwards leaves the already-tokenized inputs right-padded.
+        self.tokenizer.padding_side = "left"
         self.prepare_dataloader()
         self.ensure_test_model_ready = self.eval_engine.ensure_test_model_ready
-        self.tokenizer.padding_side = "left"
         # set stereotype availability flag from underlying dataset
         self.has_stereotype: bool = getattr(self, "has_stereotype", False)
         self._remembered_run_config_action: str | None = None

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -646,6 +646,20 @@ class BaseEvaluator(ABC):
         normalized_dataframe = dataframe.replace("", pd.NA)
         return normalized_dataframe.dropna(axis=1, how="all")
 
+    @staticmethod
+    def _preserve_directional_metric_pairs(dataframe: pd.DataFrame) -> pd.DataFrame:
+        directional_metric_pairs = [
+            ("Accuracy (%) ⬆️", "Error (%) ⬇️"),
+        ]
+        for first_column, second_column in directional_metric_pairs:
+            has_first = first_column in dataframe.columns
+            has_second = second_column in dataframe.columns
+            if has_first and not has_second:
+                dataframe[second_column] = pd.NA
+            if has_second and not has_first:
+                dataframe[first_column] = pd.NA
+        return dataframe
+
     def _append_summary_row(
         self,
         summary_file_path: Path,
@@ -655,13 +669,19 @@ class BaseEvaluator(ABC):
             existing_summary = pd.read_csv(summary_file_path)
             existing_clean = self._drop_empty_columns(existing_summary)
             row_clean = self._drop_empty_columns(summary_row)
+            existing_clean = self._preserve_directional_metric_pairs(existing_clean)
+            row_clean = self._preserve_directional_metric_pairs(row_clean)
             combined_summary = pd.concat(
                 [existing_clean, row_clean], ignore_index=True, sort=False
             )
         else:
             combined_summary = self._drop_empty_columns(summary_row)
+            combined_summary = self._preserve_directional_metric_pairs(
+                combined_summary
+            )
 
         combined_summary = self._drop_empty_columns(combined_summary)
+        combined_summary = self._preserve_directional_metric_pairs(combined_summary)
         combined_summary.to_csv(summary_file_path, index=False, float_format="%.3f")
 
     @property

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -648,6 +648,20 @@ class BaseEvaluator(ABC):
 
     @staticmethod
     def _preserve_directional_metric_pairs(dataframe: pd.DataFrame) -> pd.DataFrame:
+        """Keep paired directional metrics together in the summary schema.
+
+        Some metrics come in directional pairs (e.g. accuracy/error) that should
+        always appear together so the summary CSV has a stable set of columns.
+        When only one column of a pair is present, the missing one is added as an
+        all-empty column.
+
+        Args:
+            dataframe: Summary dataframe whose columns may be missing one half of
+                a directional metric pair.
+
+        Returns:
+            The dataframe with both columns of each directional pair present.
+        """
         directional_metric_pairs = [
             ("Accuracy (%) ⬆️", "Error (%) ⬇️"),
         ]
@@ -669,16 +683,11 @@ class BaseEvaluator(ABC):
             existing_summary = pd.read_csv(summary_file_path)
             existing_clean = self._drop_empty_columns(existing_summary)
             row_clean = self._drop_empty_columns(summary_row)
-            existing_clean = self._preserve_directional_metric_pairs(existing_clean)
-            row_clean = self._preserve_directional_metric_pairs(row_clean)
             combined_summary = pd.concat(
                 [existing_clean, row_clean], ignore_index=True, sort=False
             )
         else:
             combined_summary = self._drop_empty_columns(summary_row)
-            combined_summary = self._preserve_directional_metric_pairs(
-                combined_summary
-            )
 
         combined_summary = self._drop_empty_columns(combined_summary)
         combined_summary = self._preserve_directional_metric_pairs(combined_summary)

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -140,11 +140,7 @@ class BaseEvaluator(ABC):
         self._set_seed()
 
         # MLflow config (optional)
-        self.mlflow_config: MlflowConfig | None = (
-            self.eval_config.mlflow_config
-            if hasattr(self.eval_config, "mlflow_config")
-            else None
-        )
+        self.mlflow_config: MlflowConfig | None = self.eval_config.mlflow_config
         self.mlflow_run = None
         self.parent_run = None
         self._started_mlflow_run = False

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -66,6 +66,46 @@ except ImportError:
     RunStatus = None
 
 
+def active_mlflow_run_id() -> str | None:
+    """
+    Return the ID of the active MLflow run, if one exists.
+
+    Returns:
+        The active MLflow run ID, or None when MLflow is unavailable or no run is active.
+    """
+    if not mlflow:
+        return None
+    active_run = mlflow.active_run()
+    if active_run is None:
+        return None
+    return active_run.info.run_id
+
+
+def end_active_mlflow_run(error: bool = False) -> None:
+    """
+    End the active MLflow run with a status that reflects whether evaluation failed.
+
+    Args:
+        error: If True, mark the run as FAILED; otherwise mark it as FINISHED.
+    """
+    if not mlflow:
+        return
+    active_run = mlflow.active_run()
+    if active_run is None:
+        return
+    run_id = active_run.info.run_id
+    if RunStatus is not None:
+        status = (
+            RunStatus.to_string(RunStatus.FAILED)
+            if error
+            else RunStatus.to_string(RunStatus.FINISHED)
+        )
+    else:
+        status = "FAILED" if error else "FINISHED"
+    mlflow.end_run(status=status)
+    logging.info("Ended MLflow run %s", run_id)
+
+
 def custom_collator(batch):
     return {
         key: torch.nn.utils.rnn.pad_sequence(
@@ -712,20 +752,7 @@ class BaseEvaluator(ABC):
         """
         if not self.mlflow_config or not mlflow:
             return
-        active_run = mlflow.active_run()
-        if active_run is None:
-            return
-        run_id = active_run.info.run_id
-        if RunStatus is not None:
-            status = (
-                RunStatus.to_string(RunStatus.FAILED)
-                if error
-                else RunStatus.to_string(RunStatus.FINISHED)
-            )
-        else:
-            status = "FAILED" if error else "FINISHED"
-        mlflow.end_run(status=status)
-        logging.info("Ended MLflow run %s", run_id)
+        end_active_mlflow_run(error=error)
 
     # Hook: override in subclasses that want the dataset type in the output dir name
     def should_include_dataset_type_in_output_dir(self) -> bool:

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -585,6 +585,9 @@ class BaseEvaluator(ABC):
             # UNQOVER: unqover-<bias_type>-bias-free-text
             if parts[0] == "unqover" and len(parts) >= 2:
                 return f"UNQOVER: {parts[1]} {dataset_type_label}"
+            # Bloom: bloom-<bias_type>-<kind>-free-text
+            if parts[0] == "bloom" and len(parts) >= 2:
+                return f"Bloom: {parts[1]} {dataset_type_label}"
             # Hallucination datasets
             if slug.startswith("halueval"):
                 return "halueval"

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -687,12 +687,6 @@ class BaseEvaluator(ABC):
             combined_summary = self._drop_empty_columns(summary_row)
 
         combined_summary = self._drop_empty_columns(combined_summary)
-        has_accuracy = "Accuracy (%) ⬆️" in combined_summary.columns
-        has_error = "Error (%) ⬇️" in combined_summary.columns
-        if has_accuracy and not has_error:
-            combined_summary["Error (%) ⬇️"] = pd.NA
-        if has_error and not has_accuracy:
-            combined_summary["Accuracy (%) ⬆️"] = pd.NA
         combined_summary.to_csv(summary_file_path, index=False, float_format="%.3f")
 
     @property

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -66,21 +66,6 @@ except ImportError:
     RunStatus = None
 
 
-def active_mlflow_run_id() -> str | None:
-    """
-    Return the ID of the active MLflow run, if one exists.
-
-    Returns:
-        The active MLflow run ID, or None when MLflow is unavailable or no run is active.
-    """
-    if not mlflow:
-        return None
-    active_run = mlflow.active_run()
-    if active_run is None:
-        return None
-    return active_run.info.run_id
-
-
 def end_active_mlflow_run(error: bool = False) -> None:
     """
     End the active MLflow run with a status that reflects whether evaluation failed.
@@ -171,17 +156,6 @@ class BaseEvaluator(ABC):
             self.eval_config.lora_path_or_repo_id,
             self.mlflow_config.mlflow_tracking_uri if self.mlflow_config else None,
         )
-        if self.mlflow_config:
-            self._init_mlflow()
-            if inferred_step is not None:
-                logging.info(
-                    "Inferred MLflow metric step %s from LoRA checkpoint path %s",
-                    inferred_step,
-                    self.eval_config.lora_path_or_repo_id,
-                )
-                self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
-                    inferred_step
-                )
 
         self.data_collator = default_data_collator
         if self.model_engine == "vllm":
@@ -212,6 +186,17 @@ class BaseEvaluator(ABC):
         self.has_stereotype: bool = getattr(self, "has_stereotype", False)
         self._remembered_run_config_action: str | None = None
         self._remember_choice_prompt_asked = False
+        if self.mlflow_config:
+            self._init_mlflow()
+            if inferred_step is not None:
+                logging.info(
+                    "Inferred MLflow metric step %s from LoRA checkpoint path %s",
+                    inferred_step,
+                    self.eval_config.lora_path_or_repo_id,
+                )
+                self._inferred_mlflow_metric_step = self._resolve_mlflow_metric_step(
+                    inferred_step
+                )
         if self.eval_config.mlflow_config and mlflow:
             mlflow.log_metric("num_samples_evaluated", float(self.num_samples))
 
@@ -690,34 +675,6 @@ class BaseEvaluator(ABC):
         normalized_dataframe = dataframe.replace("", pd.NA)
         return normalized_dataframe.dropna(axis=1, how="all")
 
-    @staticmethod
-    def _preserve_directional_metric_pairs(dataframe: pd.DataFrame) -> pd.DataFrame:
-        """Keep paired directional metrics together in the summary schema.
-
-        Some metrics come in directional pairs (e.g. accuracy/error) that should
-        always appear together so the summary CSV has a stable set of columns.
-        When only one column of a pair is present, the missing one is added as an
-        all-empty column.
-
-        Args:
-            dataframe: Summary dataframe whose columns may be missing one half of
-                a directional metric pair.
-
-        Returns:
-            The dataframe with both columns of each directional pair present.
-        """
-        directional_metric_pairs = [
-            ("Accuracy (%) ⬆️", "Error (%) ⬇️"),
-        ]
-        for first_column, second_column in directional_metric_pairs:
-            has_first = first_column in dataframe.columns
-            has_second = second_column in dataframe.columns
-            if has_first and not has_second:
-                dataframe[second_column] = pd.NA
-            if has_second and not has_first:
-                dataframe[first_column] = pd.NA
-        return dataframe
-
     def _append_summary_row(
         self,
         summary_file_path: Path,
@@ -734,7 +691,12 @@ class BaseEvaluator(ABC):
             combined_summary = self._drop_empty_columns(summary_row)
 
         combined_summary = self._drop_empty_columns(combined_summary)
-        combined_summary = self._preserve_directional_metric_pairs(combined_summary)
+        has_accuracy = "Accuracy (%) ⬆️" in combined_summary.columns
+        has_error = "Error (%) ⬇️" in combined_summary.columns
+        if has_accuracy and not has_error:
+            combined_summary["Error (%) ⬇️"] = pd.NA
+        if has_error and not has_accuracy:
+            combined_summary["Accuracy (%) ⬆️"] = pd.NA
         combined_summary.to_csv(summary_file_path, index=False, float_format="%.3f")
 
     @property

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -646,6 +646,20 @@ class BaseEvaluator(ABC):
         normalized_dataframe = dataframe.replace("", pd.NA)
         return normalized_dataframe.dropna(axis=1, how="all")
 
+    @staticmethod
+    def _preserve_directional_metric_pairs(dataframe: pd.DataFrame) -> pd.DataFrame:
+        directional_metric_pairs = [
+            ("Accuracy (%) ⬆️", "Error (%) ⬇️"),
+        ]
+        for first_column, second_column in directional_metric_pairs:
+            has_first = first_column in dataframe.columns
+            has_second = second_column in dataframe.columns
+            if has_first and not has_second:
+                dataframe[second_column] = pd.NA
+            if has_second and not has_first:
+                dataframe[first_column] = pd.NA
+        return dataframe
+
     def _append_summary_row(
         self,
         summary_file_path: Path,
@@ -655,13 +669,17 @@ class BaseEvaluator(ABC):
             existing_summary = pd.read_csv(summary_file_path)
             existing_clean = self._drop_empty_columns(existing_summary)
             row_clean = self._drop_empty_columns(summary_row)
+            existing_clean = self._preserve_directional_metric_pairs(existing_clean)
+            row_clean = self._preserve_directional_metric_pairs(row_clean)
             combined_summary = pd.concat(
                 [existing_clean, row_clean], ignore_index=True, sort=False
             )
         else:
             combined_summary = self._drop_empty_columns(summary_row)
+            combined_summary = self._preserve_directional_metric_pairs(combined_summary)
 
         combined_summary = self._drop_empty_columns(combined_summary)
+        combined_summary = self._preserve_directional_metric_pairs(combined_summary)
         combined_summary.to_csv(summary_file_path, index=False, float_format="%.3f")
 
     @property

--- a/llm_behavior_eval/evaluation_utils/enums.py
+++ b/llm_behavior_eval/evaluation_utils/enums.py
@@ -25,5 +25,5 @@ UNQOVER_BIAS_TYPES: set[str] = {
     "nationality",
 }
 
-# BLOOM (synthetic scenario-based age/gender benchmark; has both bias & unbias splits)
-BLOOM_BIAS_TYPES: set[str] = {"age", "gender"}
+# BLOOM published datasets currently include age splits only.
+BLOOM_BIAS_TYPES: set[str] = {"age"}

--- a/llm_behavior_eval/evaluation_utils/enums.py
+++ b/llm_behavior_eval/evaluation_utils/enums.py
@@ -24,3 +24,6 @@ UNQOVER_BIAS_TYPES: set[str] = {
     "race",
     "nationality",
 }
+
+# BLOOM (synthetic scenario-based age/gender benchmark; has both bias & unbias splits)
+BLOOM_BIAS_TYPES: set[str] = {"age", "gender"}

--- a/llm_behavior_eval/evaluation_utils/enums.py
+++ b/llm_behavior_eval/evaluation_utils/enums.py
@@ -27,3 +27,37 @@ UNQOVER_BIAS_TYPES: set[str] = {
 
 # BLOOM published datasets currently include age splits only.
 BLOOM_BIAS_TYPES: set[str] = {"age"}
+
+BIAS_KINDS = {"bias", "unbias"}
+BBQ_BIAS_BEHAVIOR = (
+    BBQ_BIAS_TYPES,
+    BIAS_KINDS,
+    "For BBQ use 'bias:<bias_type>' or 'unbias:<bias_type>'",
+    "BBQ",
+)
+THREE_PART_BIAS_BEHAVIORS: dict[str, tuple[set[str], set[str], str, str]] = {
+    "unqover": (
+        UNQOVER_BIAS_TYPES,
+        {"bias"},
+        "UNQOVER supports only 'bias:<bias_type>' (no 'unbias' for UNQOVER)",
+        "UNQOVER",
+    ),
+    "bloom": (
+        BLOOM_BIAS_TYPES,
+        BIAS_KINDS,
+        "BLOOM supports 'bloom:bias:<type>' or 'bloom:unbias:<type>'",
+        "BLOOM",
+    ),
+}
+HALUEVAL_ALIAS = {"hallu", "hallucination"}
+MEDHALLU_ALIAS = {"hallu-med", "hallucination-med"}
+INJECTION_ALIAS = {"prompt-injection"}
+BEHAVIOR_PRESET_ERROR = "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection'"
+TRUSTED_MODEL_PROVIDERS = {
+    "hirundo-io",
+    "nvidia",
+    "meta-llama",
+    "google",
+    "aisingapore",
+    "LGAI-EXAONE",
+}

--- a/llm_behavior_eval/evaluation_utils/evaluate_factory.py
+++ b/llm_behavior_eval/evaluation_utils/evaluate_factory.py
@@ -31,7 +31,7 @@ class EvaluateFactory:
             from .free_text_injection_evaluator import FreeTextPromptInjectionEvaluator
 
             return FreeTextPromptInjectionEvaluator(eval_config, dataset_config)
-        elif "bbq" in dataset_id or "unqover" in dataset_id:
+        elif "bbq" in dataset_id or "unqover" in dataset_id or "bloom" in dataset_id:
             from .free_text_bias_evaluator import FreeTextBiasEvaluator
 
             return FreeTextBiasEvaluator(eval_config, dataset_config)

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -307,8 +307,13 @@ def test_dataset_is_tokenized_with_left_padding(
     capture_state: CaptureState,
     stub_tokenizer: StubTokenizer,
 ) -> None:
-    # The tokenizer defaults to right-padding; the evaluator must flip it to
-    # "left" before the dataset is tokenized in prepare_dataloader().
+    """Inputs must be left-padded for correct decoder-only generation.
+
+    The tokenizer defaults to right-padding; the evaluator must flip it to
+    "left" BEFORE the dataset is tokenized in prepare_dataloader(). Setting it
+    afterwards (the previous bug) leaves the cached inputs right-padded, which
+    produces garbage generations.
+    """
     assert stub_tokenizer.padding_side == "right"  # default before init
 
     evaluation_config = EvaluationConfig(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -725,6 +725,47 @@ def test_save_results_rewrites_summary_with_non_empty_columns_after_append(
     assert "Attack success rate (%) ⬇️" not in summary_rows[1]
 
 
+def test_save_results_uses_bloom_summary_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        base_evaluator_module,
+        "load_tokenizer_with_transformers",
+        lambda *_args, **_kwargs: StubTokenizer(),
+    )
+    monkeypatch.setattr(
+        base_evaluator_module, "empty_cuda_cache_if_available", lambda: None
+    )
+
+    evaluator = ConcreteEvaluator(
+        EvaluationConfig(
+            model_path_or_repo_id="meta/model",
+            results_dir=tmp_path,
+            max_samples=1,
+        ),
+        DatasetConfig(
+            file_path="hirundo-io/bloom-age-unbias-free-text",
+            dataset_type=DatasetType.UNBIAS,
+        ),
+    )
+
+    evaluator.save_results(
+        responses=[{"prompt": "test", "response": "value"}],
+        accuracy=0.80,
+        stereotyped_bias=None,
+        empty_responses=0,
+    )
+
+    summary_brief_path = tmp_path / "model" / "summary_brief.csv"
+    with summary_brief_path.open(newline="", encoding="utf-8") as summary_file:
+        summary_rows = list(csv.DictReader(summary_file))
+
+    assert summary_rows[0]["Dataset"] == "Bloom: age unbias"
+    assert summary_rows[0]["Accuracy (%) ⬆️"] == "80.000"
+    assert summary_rows[0]["Error (%) ⬇️"] == ""
+
+
 def test_save_results_marks_thinking_mode_on_when_enabled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -10,7 +10,6 @@ import pytest
 
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
-import pandas as pd
 import torch
 from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
@@ -801,54 +800,6 @@ def test_save_results_rewrites_summary_with_non_empty_columns_after_append(
     assert "Attack success rate (%) ⬇️" not in summary_rows[1]
 
 
-def test_append_summary_row_preserves_directional_metric_pair_columns(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        base_evaluator_module,
-        "load_tokenizer_with_transformers",
-        lambda *_args, **_kwargs: StubTokenizer(),
-    )
-    monkeypatch.setattr(
-        base_evaluator_module, "empty_cuda_cache_if_available", lambda: None
-    )
-
-    evaluator = ConcreteEvaluator(
-        EvaluationConfig(
-            model_path_or_repo_id="meta/model",
-            results_dir=tmp_path,
-            max_samples=1,
-        ),
-        DatasetConfig(
-            file_path="hirundo-io/bbq-gender-unbias-free-text",
-            dataset_type=DatasetType.UNBIAS,
-        ),
-    )
-
-    accuracy_summary_path = tmp_path / "accuracy_summary.csv"
-    evaluator._append_summary_row(
-        accuracy_summary_path,
-        pd.DataFrame({"Accuracy (%) ⬆️": [80.0]}),
-    )
-    accuracy_summary = pd.read_csv(accuracy_summary_path)
-
-    assert "Accuracy (%) ⬆️" in accuracy_summary.columns
-    assert "Error (%) ⬇️" in accuracy_summary.columns
-    assert accuracy_summary["Error (%) ⬇️"].isna().all()
-
-    error_summary_path = tmp_path / "error_summary.csv"
-    evaluator._append_summary_row(
-        error_summary_path,
-        pd.DataFrame({"Error (%) ⬇️": [20.0]}),
-    )
-    error_summary = pd.read_csv(error_summary_path)
-
-    assert "Accuracy (%) ⬆️" in error_summary.columns
-    assert "Error (%) ⬇️" in error_summary.columns
-    assert error_summary["Accuracy (%) ⬆️"].isna().all()
-
-
 def test_save_results_uses_bloom_summary_label(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -887,7 +838,7 @@ def test_save_results_uses_bloom_summary_label(
 
     assert summary_rows[0]["Dataset"] == "Bloom: age unbias"
     assert summary_rows[0]["Accuracy (%) ⬆️"] == "80.000"
-    assert summary_rows[0]["Error (%) ⬇️"] == ""
+    assert "Error (%) ⬇️" not in summary_rows[0]
 
 
 def test_save_results_marks_thinking_mode_on_when_enabled(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -307,13 +307,8 @@ def test_dataset_is_tokenized_with_left_padding(
     capture_state: CaptureState,
     stub_tokenizer: StubTokenizer,
 ) -> None:
-    """Inputs must be left-padded for correct decoder-only generation.
-
-    The tokenizer defaults to right-padding; the evaluator must flip it to
-    "left" BEFORE the dataset is tokenized in prepare_dataloader(). Setting it
-    afterwards (the previous bug) leaves the cached inputs right-padded, which
-    produces garbage generations.
-    """
+    # The tokenizer defaults to right-padding; the evaluator must flip it to
+    # "left" before the dataset is tokenized in prepare_dataloader().
     assert stub_tokenizer.padding_side == "right"  # default before init
 
     evaluation_config = EvaluationConfig(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -10,6 +10,7 @@ import pytest
 
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
+import pandas as pd
 import torch
 from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
@@ -798,6 +799,54 @@ def test_save_results_rewrites_summary_with_non_empty_columns_after_append(
     assert summary_rows[1]["Thinking"] == "off"
     assert "Attack success rate (%) ⬇️" not in summary_rows[0]
     assert "Attack success rate (%) ⬇️" not in summary_rows[1]
+
+
+def test_append_summary_row_preserves_directional_metric_pair_columns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        base_evaluator_module,
+        "load_tokenizer_with_transformers",
+        lambda *_args, **_kwargs: StubTokenizer(),
+    )
+    monkeypatch.setattr(
+        base_evaluator_module, "empty_cuda_cache_if_available", lambda: None
+    )
+
+    evaluator = ConcreteEvaluator(
+        EvaluationConfig(
+            model_path_or_repo_id="meta/model",
+            results_dir=tmp_path,
+            max_samples=1,
+        ),
+        DatasetConfig(
+            file_path="hirundo-io/bbq-gender-unbias-free-text",
+            dataset_type=DatasetType.UNBIAS,
+        ),
+    )
+
+    accuracy_summary_path = tmp_path / "accuracy_summary.csv"
+    evaluator._append_summary_row(
+        accuracy_summary_path,
+        pd.DataFrame({"Accuracy (%) ⬆️": [80.0]}),
+    )
+    accuracy_summary = pd.read_csv(accuracy_summary_path)
+
+    assert "Accuracy (%) ⬆️" in accuracy_summary.columns
+    assert "Error (%) ⬇️" in accuracy_summary.columns
+    assert accuracy_summary["Error (%) ⬇️"].isna().all()
+
+    error_summary_path = tmp_path / "error_summary.csv"
+    evaluator._append_summary_row(
+        error_summary_path,
+        pd.DataFrame({"Error (%) ⬇️": [20.0]}),
+    )
+    error_summary = pd.read_csv(error_summary_path)
+
+    assert "Accuracy (%) ⬆️" in error_summary.columns
+    assert "Error (%) ⬇️" in error_summary.columns
+    assert error_summary["Accuracy (%) ⬆️"].isna().all()
 
 
 def test_save_results_uses_bloom_summary_label(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -257,6 +257,51 @@ def test_prepare_dataloader_receives_eval_engine_tokenizer(
     assert capture_state.engine_dataset == evaluator.eval_dataset
 
 
+def test_mlflow_initializes_after_dataloader_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capture_state: CaptureState,
+) -> None:
+    class _MlflowRunInfo:
+        run_id = "run-id"
+
+    class _MlflowRun:
+        info = _MlflowRunInfo()
+
+    class _MlflowStub:
+        def active_run(self) -> None:
+            return None
+
+        def set_tracking_uri(self, _tracking_uri: str) -> None:
+            return None
+
+        def set_experiment(self, _experiment_name: str) -> None:
+            return None
+
+        def start_run(self, *, run_name: str) -> _MlflowRun:
+            del run_name
+            assert capture_state.set_dataset_calls
+            return _MlflowRun()
+
+        def log_metric(self, _key: str, _value: float) -> None:
+            return None
+
+    monkeypatch.setattr(base_evaluator_module, "mlflow", _MlflowStub())
+
+    ConcreteEvaluator(
+        EvaluationConfig(
+            model_path_or_repo_id="meta/model",
+            results_dir=tmp_path,
+            max_samples=1,
+            mlflow_config=MlflowConfig(),
+        ),
+        DatasetConfig(
+            file_path="repo/dataset",
+            dataset_type=DatasetType.BIAS,
+        ),
+    )
+
+
 def test_dataset_is_tokenized_with_left_padding(
     tmp_path: Path,
     capture_state: CaptureState,

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -66,6 +66,7 @@ class CaptureState:
     thinking_end_token: str | None = None
     pass_max_answer_tokens: bool | None = None
     token: str | None = None
+    padding_side_at_preprocess: str | None = None
     init_args: tuple[str, DatasetType] | None = None
     engine_inits: list[bool] = field(default_factory=list)
     set_dataset_calls: list[tuple[bool, Sized]] = field(default_factory=list)
@@ -177,6 +178,10 @@ def patch_custom_dataset(
             token: str | None = None,
         ) -> StubDataset:
             capture_state.tokenizer = tokenizer
+            # Record the padding side AT tokenization time. The tokenizer object
+            # is mutated later, so reading it after init would always see "left";
+            # capturing it here is what detects right-padded inputs.
+            capture_state.padding_side_at_preprocess = tokenizer.padding_side
             capture_state.trust_remote_code = trust_remote_code
             capture_state.max_answer_tokens = max_answer_tokens
             capture_state.enable_thinking = enable_thinking
@@ -250,6 +255,36 @@ def test_prepare_dataloader_receives_eval_engine_tokenizer(
     assert evaluator.eval_loader == "loader"
     assert evaluator.num_samples == 3
     assert capture_state.engine_dataset == evaluator.eval_dataset
+
+
+def test_dataset_is_tokenized_with_left_padding(
+    tmp_path: Path,
+    capture_state: CaptureState,
+    stub_tokenizer: StubTokenizer,
+) -> None:
+    """Inputs must be left-padded for correct decoder-only generation.
+
+    The tokenizer defaults to right-padding; the evaluator must flip it to
+    "left" BEFORE the dataset is tokenized in prepare_dataloader(). Setting it
+    afterwards (the previous bug) leaves the cached inputs right-padded, which
+    produces garbage generations.
+    """
+    assert stub_tokenizer.padding_side == "right"  # default before init
+
+    evaluation_config = EvaluationConfig(
+        model_path_or_repo_id="meta/model",
+        results_dir=tmp_path,
+        batch_size=None,
+        max_samples=10,
+    )
+    dataset_config_instance = DatasetConfig(
+        file_path="repo/dataset",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    ConcreteEvaluator(evaluation_config, dataset_config_instance)
+
+    assert capture_state.padding_side_at_preprocess == "left"
 
 
 def test_process_judge_prompts_batch_uses_sampling_config(tmp_path: Path) -> None:

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -178,9 +178,7 @@ def patch_custom_dataset(
             token: str | None = None,
         ) -> StubDataset:
             capture_state.tokenizer = tokenizer
-            # Record the padding side AT tokenization time. The tokenizer object
-            # is mutated later, so reading it after init would always see "left";
-            # capturing it here is what detects right-padded inputs.
+            # Capture tokenization-time padding before later tokenizer mutations.
             capture_state.padding_side_at_preprocess = tokenizer.padding_side
             capture_state.trust_remote_code = trust_remote_code
             capture_state.max_answer_tokens = max_answer_tokens
@@ -307,13 +305,7 @@ def test_dataset_is_tokenized_with_left_padding(
     capture_state: CaptureState,
     stub_tokenizer: StubTokenizer,
 ) -> None:
-    """Inputs must be left-padded for correct decoder-only generation.
-
-    The tokenizer defaults to right-padding; the evaluator must flip it to
-    "left" BEFORE the dataset is tokenized in prepare_dataloader(). Setting it
-    afterwards (the previous bug) leaves the cached inputs right-padded, which
-    produces garbage generations.
-    """
+    """Inputs must be left-padded before dataset tokenization."""
     assert stub_tokenizer.padding_side == "right"  # default before init
 
     evaluation_config = EvaluationConfig(

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from llm_behavior_eval.evaluate import _behavior_presets
+from llm_behavior_eval.evaluation_utils.dataset_config import DatasetConfig
+from llm_behavior_eval.evaluation_utils.enums import DatasetType
+from llm_behavior_eval.evaluation_utils.eval_config import EvaluationConfig
+from llm_behavior_eval.evaluation_utils.evaluate_factory import EvaluateFactory
+from llm_behavior_eval.evaluation_utils.free_text_bias_evaluator import (
+    FreeTextBiasEvaluator,
+)
+
+
+def test_bloom_behavior_presets() -> None:
+    assert _behavior_presets("bloom:bias:age") == [
+        "hirundo-io/bloom-age-bias-free-text"
+    ]
+    assert _behavior_presets("bloom:unbias:age") == [
+        "hirundo-io/bloom-age-unbias-free-text"
+    ]
+    assert _behavior_presets("bloom:bias:all") == [
+        "hirundo-io/bloom-age-bias-free-text",
+        "hirundo-io/bloom-gender-bias-free-text",
+    ]
+
+
+def test_bloom_behavior_presets_normalize_parts_and_support_unbias_all() -> None:
+    assert _behavior_presets(" BLOOM : UNBIAS : ALL ") == [
+        "hirundo-io/bloom-age-unbias-free-text",
+        "hirundo-io/bloom-gender-unbias-free-text",
+    ]
+
+
+def test_bloom_behavior_preset_rejects_invalid_kind() -> None:
+    with pytest.raises(ValueError, match="bloom:bias:<type>"):
+        _behavior_presets("bloom:neutral:age")
+
+
+def test_bloom_behavior_preset_rejects_invalid_type() -> None:
+    with pytest.raises(ValueError, match="BLOOM supports"):
+        _behavior_presets("bloom:bias:race")
+
+
+def test_factory_routes_bloom_to_free_text_bias_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(FreeTextBiasEvaluator, "__init__", lambda self, *_args: None)
+    eval_config = EvaluationConfig(
+        model_path_or_repo_id="fake/model",
+        results_dir=tmp_path,
+    )
+    dataset_config = DatasetConfig(
+        file_path="hirundo-io/bloom-age-bias-free-text",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    evaluator = EvaluateFactory.create_evaluator(eval_config, dataset_config)
+
+    assert isinstance(evaluator, FreeTextBiasEvaluator)

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -21,14 +21,12 @@ def test_bloom_behavior_presets() -> None:
     ]
     assert _behavior_presets("bloom:bias:all") == [
         "hirundo-io/bloom-age-bias-free-text",
-        "hirundo-io/bloom-gender-bias-free-text",
     ]
 
 
 def test_bloom_behavior_presets_normalize_parts_and_support_unbias_all() -> None:
     assert _behavior_presets(" BLOOM : UNBIAS : ALL ") == [
         "hirundo-io/bloom-age-unbias-free-text",
-        "hirundo-io/bloom-gender-unbias-free-text",
     ]
 
 
@@ -40,6 +38,11 @@ def test_bloom_behavior_preset_rejects_invalid_kind() -> None:
 def test_bloom_behavior_preset_rejects_invalid_type() -> None:
     with pytest.raises(ValueError, match="BLOOM supports"):
         _behavior_presets("bloom:bias:race")
+
+
+def test_bloom_behavior_preset_rejects_unpublished_gender_split() -> None:
+    with pytest.raises(ValueError, match="BLOOM supports"):
+        _behavior_presets("bloom:bias:gender")
 
 
 def test_factory_routes_bloom_to_free_text_bias_evaluator(

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -154,6 +154,58 @@ def test_main_skips_missing_dataset_and_continues(
     assert "Skipping dataset hirundo-io/halueval" in caplog.text
 
 
+def test_main_ends_mlflow_run_when_initial_evaluator_constructor_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _RunInfo:
+        run_id = "started-run"
+
+    class _Run:
+        info = _RunInfo()
+
+    class _MlflowStub:
+        def __init__(self) -> None:
+            started_run = _Run()
+            self.active_runs = [None, started_run, started_run, None]
+            self.ended_statuses: list[str] = []
+
+        def active_run(self):
+            return self.active_runs.pop(0)
+
+        def end_run(self, *, status: str) -> None:
+            self.ended_statuses.append(status)
+
+    mlflow_stub = _MlflowStub()
+    captured: list[DatasetConfig] = []
+
+    def _fake_create(
+        eval_config: EvaluationConfig, dataset_config: DatasetConfig
+    ) -> _StubEvaluator:
+        if dataset_config.file_path == "hirundo-io/halueval":
+            raise RuntimeError(
+                "Failed to load dataset 'hirundo-io/halueval'. "
+                "Check that the identifier is correct."
+            )
+        captured.append(dataset_config)
+        return _StubEvaluator()
+
+    monkeypatch.setattr(
+        "llm_behavior_eval.evaluation_utils.base_evaluator.mlflow", mlflow_stub
+    )
+    monkeypatch.setattr(
+        evaluate.EvaluateFactory,
+        "create_evaluator",
+        staticmethod(_fake_create),
+    )
+
+    evaluate.main("fake/model", "hallu,prompt-injection", use_mlflow=True)
+
+    assert mlflow_stub.ended_statuses == ["FAILED"]
+    assert [config.file_path for config in captured] == [
+        "hirundo-io/prompt-injection-purple-llama"
+    ]
+
+
 def test_main_passes_model_output_dir_override(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -122,6 +122,38 @@ def test_main_passes_judge_quantization_flag(
     assert capture_eval_config[-1].use_4bit_judge is True
 
 
+def test_main_skips_missing_dataset_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: list[DatasetConfig] = []
+
+    def _fake_create(
+        eval_config: EvaluationConfig, dataset_config: DatasetConfig
+    ) -> _StubEvaluator:
+        if dataset_config.file_path == "hirundo-io/halueval":
+            raise RuntimeError(
+                "Failed to load dataset 'hirundo-io/halueval'. "
+                "Check that the identifier is correct."
+            )
+        captured.append(dataset_config)
+        return _StubEvaluator()
+
+    monkeypatch.setattr(
+        evaluate.EvaluateFactory,
+        "create_evaluator",
+        staticmethod(_fake_create),
+    )
+
+    with caplog.at_level("WARNING"):
+        evaluate.main("fake/model", "hallu,prompt-injection")
+
+    assert [config.file_path for config in captured] == [
+        "hirundo-io/prompt-injection-purple-llama"
+    ]
+    assert "Skipping dataset hirundo-io/halueval" in caplog.text
+
+
 def test_main_passes_model_output_dir_override(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -246,7 +246,6 @@ def test_main_does_not_create_vllm_config_when_not_using_vllm(
 def test_main_validates_vllm_config_only_with_vllm(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
-    """Test that vllm_config can only be used when vLLM is actually enabled."""
     # This would raise an error when instantiating EvaluationConfig
     # with vllm_config but no vLLM engine selected
     from pathlib import Path
@@ -268,7 +267,6 @@ def test_main_validates_vllm_config_only_with_vllm(
 
 
 def test_eval_config_validates_lora_only_with_vllm() -> None:
-    """Test that lora_path_or_repo_id can only be used when vLLM is enabled."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -289,7 +287,6 @@ def test_eval_config_validates_lora_only_with_vllm() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_inference_engine() -> None:
-    """Test that lora_path_or_repo_id is allowed when inference_engine is vllm."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -307,7 +304,6 @@ def test_eval_config_allows_lora_with_vllm_inference_engine() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_model_engine() -> None:
-    """Test that lora_path_or_repo_id is allowed when model_engine is vllm."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -325,7 +321,6 @@ def test_eval_config_allows_lora_with_vllm_model_engine() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_config() -> None:
-    """Test that lora_path_or_repo_id is allowed when vllm_config is provided."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -347,7 +342,6 @@ def test_eval_config_allows_lora_with_vllm_config() -> None:
 
 
 def test_eval_config_allows_none_lora_path() -> None:
-    """Test that lora_path_or_repo_id can be None."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -412,7 +406,6 @@ def test_eval_config_rejects_parent_traversal_in_model_output_dir() -> None:
 def test_main_passes_answer_tokens_and_judge_tokens_via_cli(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
-    """Test that max_answer_tokens and max_judge_tokens CLI options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",
@@ -427,7 +420,6 @@ def test_main_passes_answer_tokens_and_judge_tokens_via_cli(
 def test_main_uses_default_answer_and_judge_tokens(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
-    """Test that default values are applied when tokens are not specified."""
     evaluate.main("fake/model", "hallu")
     eval_config = capture_eval_config[-1]
     assert eval_config.max_answer_tokens == 128  # Default from EvaluationConfig
@@ -437,7 +429,6 @@ def test_main_uses_default_answer_and_judge_tokens(
 def test_main_passes_model_inference_config_options(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
-    """Test that model inference options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",
@@ -454,7 +445,6 @@ def test_main_passes_model_inference_config_options(
 def test_main_passes_judge_inference_config_options(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
-    """Test that judge inference options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -246,6 +246,7 @@ def test_main_does_not_create_vllm_config_when_not_using_vllm(
 def test_main_validates_vllm_config_only_with_vllm(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
+    """Test that vllm_config can only be used when vLLM is actually enabled."""
     # This would raise an error when instantiating EvaluationConfig
     # with vllm_config but no vLLM engine selected
     from pathlib import Path
@@ -267,6 +268,7 @@ def test_main_validates_vllm_config_only_with_vllm(
 
 
 def test_eval_config_validates_lora_only_with_vllm() -> None:
+    """Test that lora_path_or_repo_id can only be used when vLLM is enabled."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -287,6 +289,7 @@ def test_eval_config_validates_lora_only_with_vllm() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_inference_engine() -> None:
+    """Test that lora_path_or_repo_id is allowed when inference_engine is vllm."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -304,6 +307,7 @@ def test_eval_config_allows_lora_with_vllm_inference_engine() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_model_engine() -> None:
+    """Test that lora_path_or_repo_id is allowed when model_engine is vllm."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -321,6 +325,7 @@ def test_eval_config_allows_lora_with_vllm_model_engine() -> None:
 
 
 def test_eval_config_allows_lora_with_vllm_config() -> None:
+    """Test that lora_path_or_repo_id is allowed when vllm_config is provided."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -342,6 +347,7 @@ def test_eval_config_allows_lora_with_vllm_config() -> None:
 
 
 def test_eval_config_allows_none_lora_path() -> None:
+    """Test that lora_path_or_repo_id can be None."""
     from pathlib import Path
 
     from llm_behavior_eval.evaluation_utils.eval_config import (
@@ -406,6 +412,7 @@ def test_eval_config_rejects_parent_traversal_in_model_output_dir() -> None:
 def test_main_passes_answer_tokens_and_judge_tokens_via_cli(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
+    """Test that max_answer_tokens and max_judge_tokens CLI options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",
@@ -420,6 +427,7 @@ def test_main_passes_answer_tokens_and_judge_tokens_via_cli(
 def test_main_uses_default_answer_and_judge_tokens(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
+    """Test that default values are applied when tokens are not specified."""
     evaluate.main("fake/model", "hallu")
     eval_config = capture_eval_config[-1]
     assert eval_config.max_answer_tokens == 128  # Default from EvaluationConfig
@@ -429,6 +437,7 @@ def test_main_uses_default_answer_and_judge_tokens(
 def test_main_passes_model_inference_config_options(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
+    """Test that model inference options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",
@@ -445,6 +454,7 @@ def test_main_passes_model_inference_config_options(
 def test_main_passes_judge_inference_config_options(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:
+    """Test that judge inference options are passed correctly."""
     evaluate.main(
         "fake/model",
         "hallu",

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -122,10 +122,7 @@ def test_main_passes_judge_quantization_flag(
     assert capture_eval_config[-1].use_4bit_judge is True
 
 
-def test_main_skips_missing_dataset_and_continues(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_main_raises_missing_dataset_error(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[DatasetConfig] = []
 
     def _fake_create(
@@ -145,13 +142,12 @@ def test_main_skips_missing_dataset_and_continues(
         staticmethod(_fake_create),
     )
 
-    with caplog.at_level("WARNING"):
+    with pytest.raises(
+        RuntimeError, match="Failed to load dataset 'hirundo-io/halueval'"
+    ):
         evaluate.main("fake/model", "hallu,prompt-injection")
 
-    assert [config.file_path for config in captured] == [
-        "hirundo-io/prompt-injection-purple-llama"
-    ]
-    assert "Skipping dataset hirundo-io/halueval" in caplog.text
+    assert captured == []
 
 
 def test_main_passes_model_output_dir_override(

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -154,58 +154,6 @@ def test_main_skips_missing_dataset_and_continues(
     assert "Skipping dataset hirundo-io/halueval" in caplog.text
 
 
-def test_main_ends_mlflow_run_when_initial_evaluator_constructor_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _RunInfo:
-        run_id = "started-run"
-
-    class _Run:
-        info = _RunInfo()
-
-    class _MlflowStub:
-        def __init__(self) -> None:
-            started_run = _Run()
-            self.active_runs = [None, started_run, started_run, None]
-            self.ended_statuses: list[str] = []
-
-        def active_run(self):
-            return self.active_runs.pop(0)
-
-        def end_run(self, *, status: str) -> None:
-            self.ended_statuses.append(status)
-
-    mlflow_stub = _MlflowStub()
-    captured: list[DatasetConfig] = []
-
-    def _fake_create(
-        eval_config: EvaluationConfig, dataset_config: DatasetConfig
-    ) -> _StubEvaluator:
-        if dataset_config.file_path == "hirundo-io/halueval":
-            raise RuntimeError(
-                "Failed to load dataset 'hirundo-io/halueval'. "
-                "Check that the identifier is correct."
-            )
-        captured.append(dataset_config)
-        return _StubEvaluator()
-
-    monkeypatch.setattr(
-        "llm_behavior_eval.evaluation_utils.base_evaluator.mlflow", mlflow_stub
-    )
-    monkeypatch.setattr(
-        evaluate.EvaluateFactory,
-        "create_evaluator",
-        staticmethod(_fake_create),
-    )
-
-    evaluate.main("fake/model", "hallu,prompt-injection", use_mlflow=True)
-
-    assert mlflow_stub.ended_statuses == ["FAILED"]
-    assert [config.file_path for config in captured] == [
-        "hirundo-io/prompt-injection-purple-llama"
-    ]
-
-
 def test_main_passes_model_output_dir_override(
     capture_eval_config: list[EvaluationConfig],
 ) -> None:


### PR DESCRIPTION
# User description
Adds Bloom as a new social-bias benchmark source, wired similarly to UNQOVER and evaluated through the existing FreeTextBiasEvaluator. This change introduces Bloom age bias dimension with bias/unbias presets, dataset routing, reporting support, documentation and test coverage.

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend behavior preset parsing so Bloom bias/unbias splits travel through the shared bias evaluator infrastructure and document the new flows for users, while keeping dataset routing consistent in the CLI parsing layer. Strengthen evaluation execution bookkeeping by tracking dataset files, ensuring tokenizer padding, and centralizing MLflow lifecycle handling so runtime reporting stays accurate even when failures occur.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/137?tool=ast&topic=Eval+Run+Stability>Eval Run Stability</a>
        </td><td>Stabilize evaluation execution by tracking dataset file paths during generation, guarding MLflow cleanup/status updates via <code>BaseEvaluator</code>, ensuring the tokenizer is left-padded before preprocessing, and proving those guarantees with base evaluator tests so reporting and cleanup stay correct across runs.<details><summary>Modified files (3)</summary><ul><li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>tests/test_base_evaluator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>codex@openai.com</td><td>Refactor bias behavior...</td><td>June 16, 2026</td></tr>
<tr><td>ilagri@gmail.com</td><td>Refactor BBQ bias beha...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/137?tool=ast&topic=Bloom+Bias+Flow>Bloom Bias Flow</a>
        </td><td>Route Bloom bias and unbias presets through <code>_behavior_presets</code>, the shared behavior enums, and <code>EvaluateFactory</code>, document the new benchmark and dataset identifiers, and verify the feature with dedicated behavior and factory tests so Bloom data inherits the existing <code>FreeTextBiasEvaluator</code> flow.<details><summary>Modified files (5)</summary><ul><li>README.md</li>
<li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/enums.py</li>
<li>llm_behavior_eval/evaluation_utils/evaluate_factory.py</li>
<li>tests/test_bloom.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>codex@openai.com</td><td>Refactor bias behavior...</td><td>June 16, 2026</td></tr>
<tr><td>ilagri@gmail.com</td><td>Refactor BBQ bias beha...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/137?tool=ast&topic=CLI+Error+Path>CLI Error Path</a>
        </td><td>Validate CLI error handling by ensuring missing dataset failures are surfaced without progressing to dataset creation and confirming <code>EvaluateFactory</code> stubs aren’t invoked when initial dataset loading fails.<details><summary>Modified files (1)</summary><ul><li>tests/test_evaluate_cli.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/137?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>