### PR TITLE
LLM-110: Add Bloom gender and race behavior presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,11 @@ llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct unqover:bias:all
 
 - **Bloom (bias)** — evaluate a model on Bloom scenario-based bias:
 ```bash
-llm-behavior-eval google/gemma-2b-it bloom:bias:age
 llm-behavior-eval google/gemma-2b-it bloom:bias:race
 ```
 
 - **Bloom (unbias)** — evaluate a model on Bloom disambiguated scenarios:
 ```bash
-llm-behavior-eval google/gemma-2b-it bloom:unbias:age
 llm-behavior-eval google/gemma-2b-it bloom:unbias:gender
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct unqover:bias:all
 
 - **Bloom (bias)** — evaluate a model on Bloom scenario-based bias:
 ```bash
+llm-behavior-eval google/gemma-2b-it bloom:bias:age
 llm-behavior-eval google/gemma-2b-it bloom:bias:race
 ```
 
 - **Bloom (unbias)** — evaluate a model on Bloom disambiguated scenarios:
 ```bash
+llm-behavior-eval google/gemma-2b-it bloom:unbias:age
 llm-behavior-eval google/gemma-2b-it bloom:unbias:gender
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This toolkit evaluates three classes of behaviors:
     - **bias** (ambiguous) and **unbias** (disambiguated) for: `gender`, `race`, `nationality`, `physical`, `age`, `religion`.
     - Only BBQ provides both ambiguous and disambiguated versions.
   - **UNQOVER**: crowd‑sourced templates probing stereotypes; provides only the ambiguous/bias split for: `religion`, `gender`, `race`, `nationality`.
-  - **Bloom**: synthetic scenario-based benchmark with paired **bias** and **unbias** splits. Currently published for: `age`.
+  - **Bloom**: synthetic scenario-based benchmark with paired **bias** and **unbias** splits for: `age`, `gender`, `race`.
 
 - **Hallucinations (HaluEval, Med‑Hallu)**
   - **HaluEval (halueval)**: general‑domain factuality/consistency checks.
@@ -125,12 +125,12 @@ llm-behavior-eval meta-llama/Llama-3.1-8B-Instruct unqover:bias:all
 
 - **Bloom (bias)** — evaluate a model on Bloom scenario-based bias:
 ```bash
-llm-behavior-eval google/gemma-2b-it bloom:bias:age
+llm-behavior-eval google/gemma-2b-it bloom:bias:race
 ```
 
 - **Bloom (unbias)** — evaluate a model on Bloom disambiguated scenarios:
 ```bash
-llm-behavior-eval google/gemma-2b-it bloom:unbias:age
+llm-behavior-eval google/gemma-2b-it bloom:unbias:gender
 ```
 
 - **Hallucination (general)** — HaluEval free‑text:
@@ -196,7 +196,7 @@ Per‑model summaries are saved as `results/<model>/summary_full.csv` (full metr
 
 - BBQ: `BBQ: <gender|race|nationality|physical|age|religion> <bias|unbias>`
 - UNQOVER: `UNQOVER: <religion|gender|race|nationality> <bias>`
-- Bloom: `Bloom: <age> <bias|unbias>`
+- Bloom: `Bloom: <age|gender|race> <bias|unbias>`
 - Hallucination: `halueval` or `medhallu`
 - Prompt Injection: `prompt-injection-purple-llama`
 

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -17,6 +17,7 @@ from llm_behavior_eval.evaluation_utils.dataset_config import (
 from llm_behavior_eval.evaluation_utils.enums import (
     BBQ_BIAS_BEHAVIOR,
     BEHAVIOR_PRESET_ERROR,
+    BLOOM_BIAS_TYPES,
     HALUEVAL_ALIAS,
     INJECTION_ALIAS,
     MEDHALLU_ALIAS,
@@ -139,6 +140,7 @@ def _behavior_presets(behavior: str) -> list[str]:
     #   - bias_type can be a concrete type or 'all'
     # ["bloom", kind, bias_type] for Bloom, where kind in {bias, unbias}
     #   - bias_type can be a concrete type or 'all'
+    # ["bloom", "bias", bias_type, "ambiguous"] for Bloom ambiguous-only bias
     if len(behavior_parts) == 2:
         kind, bias_type = behavior_parts
         allowed_types, allowed_kinds, kind_error, support_label = BBQ_BIAS_BEHAVIOR
@@ -169,6 +171,17 @@ def _behavior_presets(behavior: str) -> list[str]:
             kind_error,
             support_label,
         )
+
+    if len(behavior_parts) == 4:
+        prefix, kind, bias_type, context = behavior_parts
+        if (
+            prefix == "bloom"
+            and kind == "bias"
+            and context == "ambiguous"
+            and bias_type in BLOOM_BIAS_TYPES
+        ):
+            return [f"hirundo-io/bloom-{bias_type}-ambiguous-bias-free-text"]
+        raise ValueError("Use 'bloom:bias:<type>:ambiguous'")
 
     raise ValueError(BEHAVIOR_PRESET_ERROR)
 

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -609,7 +609,10 @@ class BaseEvaluator(ABC):
             if parts[0] == "unqover" and len(parts) >= 2:
                 return f"UNQOVER: {parts[1]} {dataset_type_label}"
             # Bloom: bloom-<bias_type>-<kind>-free-text
+            # Bloom ambiguous: bloom-<bias_type>-ambiguous-bias-free-text
             if parts[0] == "bloom" and len(parts) >= 2:
+                if len(parts) >= 4 and parts[2] == "ambiguous":
+                    return f"Bloom: {parts[1]} ambiguous {dataset_type_label}"
                 return f"Bloom: {parts[1]} {dataset_type_label}"
             # Hallucination datasets
             if slug.startswith("halueval"):

--- a/llm_behavior_eval/evaluation_utils/enums.py
+++ b/llm_behavior_eval/evaluation_utils/enums.py
@@ -53,7 +53,7 @@ HALUEVAL_ALIAS = {"hallu", "hallucination"}
 MEDHALLU_ALIAS = {"hallu-med", "hallucination-med"}
 INJECTION_ALIAS = {"prompt-injection"}
 REFUSAL_ALIAS = {"refusal"}
-BEHAVIOR_PRESET_ERROR = "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'hallu' | 'hallu-med' | 'prompt-injection' | 'refusal:xstest' | 'refusal:orbench' | 'refusal:all'"
+BEHAVIOR_PRESET_ERROR = "--behavior must be 'bias:<type|all>' | 'unbias:<type|all>' | 'unqover:bias:<type|all>' | 'bloom:bias:<type|all>' | 'bloom:unbias:<type|all>' | 'bloom:bias:<type>:ambiguous' | 'hallu' | 'hallu-med' | 'prompt-injection' | 'refusal:xstest' | 'refusal:orbench' | 'refusal:all'"
 TRUSTED_MODEL_PROVIDERS = {
     "hirundo-io",
     "nvidia",

--- a/llm_behavior_eval/evaluation_utils/enums.py
+++ b/llm_behavior_eval/evaluation_utils/enums.py
@@ -25,8 +25,8 @@ UNQOVER_BIAS_TYPES: set[str] = {
     "nationality",
 }
 
-# BLOOM published datasets currently include age splits only.
-BLOOM_BIAS_TYPES: set[str] = {"age"}
+# BLOOM supports paired scenario-based bias and unbias splits.
+BLOOM_BIAS_TYPES: set[str] = {"age", "gender", "race"}
 
 BIAS_KINDS = {"bias", "unbias"}
 BBQ_BIAS_BEHAVIOR = (

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -857,6 +857,46 @@ def test_save_results_uses_bloom_summary_label(
     assert "Error (%) ⬇️" not in summary_rows[0]
 
 
+def test_save_results_uses_distinct_bloom_ambiguous_summary_label(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        base_evaluator_module,
+        "load_tokenizer_with_transformers",
+        lambda *_args, **_kwargs: StubTokenizer(),
+    )
+    monkeypatch.setattr(
+        base_evaluator_module, "empty_cuda_cache_if_available", lambda: None
+    )
+
+    evaluator = ConcreteEvaluator(
+        EvaluationConfig(
+            model_path_or_repo_id="meta/model",
+            results_dir=tmp_path,
+            max_samples=1,
+        ),
+        DatasetConfig(
+            file_path="hirundo-io/bloom-gender-ambiguous-bias-free-text",
+            dataset_type=DatasetType.BIAS,
+        ),
+    )
+
+    evaluator.save_results(
+        responses=[{"prompt": "test", "response": "value"}],
+        accuracy=0.80,
+        stereotyped_bias=None,
+        empty_responses=0,
+    )
+
+    summary_brief_path = tmp_path / "model" / "summary_brief.csv"
+    with summary_brief_path.open(newline="", encoding="utf-8") as summary_file:
+        summary_rows = list(csv.DictReader(summary_file))
+
+    assert summary_rows[0]["Dataset"] == "Bloom: gender ambiguous bias"
+    assert summary_rows[0]["Error (%) ⬇️"] == "20.000"
+
+
 def test_save_results_marks_thinking_mode_on_when_enabled(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -19,14 +19,30 @@ def test_bloom_behavior_presets() -> None:
     assert _behavior_presets("bloom:unbias:age") == [
         "hirundo-io/bloom-age-unbias-free-text"
     ]
+    assert _behavior_presets("bloom:bias:gender") == [
+        "hirundo-io/bloom-gender-bias-free-text"
+    ]
+    assert _behavior_presets("bloom:unbias:gender") == [
+        "hirundo-io/bloom-gender-unbias-free-text"
+    ]
+    assert _behavior_presets("bloom:bias:race") == [
+        "hirundo-io/bloom-race-bias-free-text"
+    ]
+    assert _behavior_presets("bloom:unbias:race") == [
+        "hirundo-io/bloom-race-unbias-free-text"
+    ]
     assert _behavior_presets("bloom:bias:all") == [
         "hirundo-io/bloom-age-bias-free-text",
+        "hirundo-io/bloom-gender-bias-free-text",
+        "hirundo-io/bloom-race-bias-free-text",
     ]
 
 
 def test_bloom_behavior_presets_normalize_parts_and_support_unbias_all() -> None:
     assert _behavior_presets(" BLOOM : UNBIAS : ALL ") == [
         "hirundo-io/bloom-age-unbias-free-text",
+        "hirundo-io/bloom-gender-unbias-free-text",
+        "hirundo-io/bloom-race-unbias-free-text",
     ]
 
 
@@ -36,13 +52,8 @@ def test_bloom_behavior_preset_rejects_invalid_kind() -> None:
 
 
 def test_bloom_behavior_preset_rejects_invalid_type() -> None:
-    with pytest.raises(ValueError, match="BLOOM supports"):
-        _behavior_presets("bloom:bias:race")
-
-
-def test_bloom_behavior_preset_rejects_unpublished_gender_split() -> None:
-    with pytest.raises(ValueError, match="BLOOM supports"):
-        _behavior_presets("bloom:bias:gender")
+    with pytest.raises(ValueError, match="BLOOM supports: age, gender, race, all"):
+        _behavior_presets("bloom:bias:religion")
 
 
 def test_factory_routes_bloom_to_free_text_bias_evaluator(

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -12,37 +12,32 @@ from llm_behavior_eval.evaluation_utils.free_text_bias_evaluator import (
 )
 
 
-def test_bloom_behavior_presets() -> None:
-    assert _behavior_presets("bloom:bias:age") == [
-        "hirundo-io/bloom-age-bias-free-text"
-    ]
-    assert _behavior_presets("bloom:unbias:age") == [
-        "hirundo-io/bloom-age-unbias-free-text"
-    ]
-    assert _behavior_presets("bloom:bias:gender") == [
-        "hirundo-io/bloom-gender-bias-free-text"
-    ]
-    assert _behavior_presets("bloom:unbias:gender") == [
-        "hirundo-io/bloom-gender-unbias-free-text"
-    ]
-    assert _behavior_presets("bloom:bias:race") == [
-        "hirundo-io/bloom-race-bias-free-text"
-    ]
-    assert _behavior_presets("bloom:unbias:race") == [
-        "hirundo-io/bloom-race-unbias-free-text"
-    ]
-    assert _behavior_presets("bloom:bias:all") == [
-        "hirundo-io/bloom-age-bias-free-text",
-        "hirundo-io/bloom-gender-bias-free-text",
-        "hirundo-io/bloom-race-bias-free-text",
-    ]
+@pytest.mark.parametrize(
+    ("behavior", "dataset_id"),
+    [
+        ("bloom:bias:age", "hirundo-io/bloom-age-bias-free-text"),
+        ("bloom:unbias:age", "hirundo-io/bloom-age-unbias-free-text"),
+        ("bloom:bias:gender", "hirundo-io/bloom-gender-bias-free-text"),
+        ("bloom:unbias:gender", "hirundo-io/bloom-gender-unbias-free-text"),
+        ("bloom:bias:race", "hirundo-io/bloom-race-bias-free-text"),
+        ("bloom:unbias:race", "hirundo-io/bloom-race-unbias-free-text"),
+    ],
+)
+def test_bloom_behavior_presets(behavior: str, dataset_id: str) -> None:
+    assert _behavior_presets(behavior) == [dataset_id]
 
 
-def test_bloom_behavior_presets_normalize_parts_and_support_unbias_all() -> None:
-    assert _behavior_presets(" BLOOM : UNBIAS : ALL ") == [
-        "hirundo-io/bloom-age-unbias-free-text",
-        "hirundo-io/bloom-gender-unbias-free-text",
-        "hirundo-io/bloom-race-unbias-free-text",
+@pytest.mark.parametrize(
+    ("behavior", "kind"),
+    [
+        ("bloom:bias:all", "bias"),
+        (" BLOOM : UNBIAS : ALL ", "unbias"),
+    ],
+)
+def test_bloom_behavior_presets_all(behavior: str, kind: str) -> None:
+    assert _behavior_presets(behavior) == [
+        f"hirundo-io/bloom-{bias_type}-{kind}-free-text"
+        for bias_type in ("age", "gender", "race")
     ]
 
 

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -28,6 +28,23 @@ def test_bloom_behavior_presets(behavior: str, dataset_id: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("behavior", "dataset_id"),
+    [
+        (
+            "bloom:bias:gender:ambiguous",
+            "hirundo-io/bloom-gender-ambiguous-bias-free-text",
+        ),
+        (
+            "bloom:bias:race:ambiguous",
+            "hirundo-io/bloom-race-ambiguous-bias-free-text",
+        ),
+    ],
+)
+def test_bloom_ambiguous_only_behavior_presets(behavior: str, dataset_id: str) -> None:
+    assert _behavior_presets(behavior) == [dataset_id]
+
+
+@pytest.mark.parametrize(
     ("behavior", "kind"),
     [
         ("bloom:bias:all", "bias"),
@@ -49,6 +66,11 @@ def test_bloom_behavior_preset_rejects_invalid_kind() -> None:
 def test_bloom_behavior_preset_rejects_invalid_type() -> None:
     with pytest.raises(ValueError, match="BLOOM supports: age, gender, race, all"):
         _behavior_presets("bloom:bias:religion")
+
+
+def test_bloom_ambiguous_only_behavior_preset_rejects_unbias() -> None:
+    with pytest.raises(ValueError, match="bloom:bias:<type>:ambiguous"):
+        _behavior_presets("bloom:unbias:gender:ambiguous")
 
 
 def test_factory_routes_bloom_to_free_text_bias_evaluator(

--- a/tests/test_bloom.py
+++ b/tests/test_bloom.py
@@ -1,7 +1,12 @@
+import csv
+import json
+from contextlib import nullcontext
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+import llm_behavior_eval.evaluation_utils.base_evaluator as base_evaluator_module
 from llm_behavior_eval.evaluate import _behavior_presets
 from llm_behavior_eval.evaluation_utils.dataset_config import DatasetConfig
 from llm_behavior_eval.evaluation_utils.enums import DatasetType
@@ -9,6 +14,7 @@ from llm_behavior_eval.evaluation_utils.eval_config import EvaluationConfig
 from llm_behavior_eval.evaluation_utils.evaluate_factory import EvaluateFactory
 from llm_behavior_eval.evaluation_utils.free_text_bias_evaluator import (
     FreeTextBiasEvaluator,
+    _BiasGenerationRecord,
 )
 
 
@@ -90,3 +96,162 @@ def test_factory_routes_bloom_to_free_text_bias_evaluator(
     evaluator = EvaluateFactory.create_evaluator(eval_config, dataset_config)
 
     assert isinstance(evaluator, FreeTextBiasEvaluator)
+
+
+def test_ambiguous_bloom_evaluate_parses_and_scores_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class StubTokenizer:
+        pad_token = "<pad>"
+        eos_token = "</s>"
+        name_or_path = "stub-tokenizer"
+        chat_template = ""
+        padding_side = "right"
+
+        def apply_chat_template(
+            self,
+            conversation: list[dict[str, str]],
+            **_kwargs: Any,
+        ) -> str:
+            return "\n".join(message["content"] for message in conversation)
+
+    class StubEvalEngine:
+        def __init__(
+            self,
+            _data_collator: Any,
+            _eval_config: EvaluationConfig,
+            *,
+            is_judge: bool = False,
+            **_kwargs: Any,
+        ) -> None:
+            self.tokenizer = StubTokenizer()
+            self.is_judge = is_judge
+
+        def get_batch_size(self) -> int:
+            return 1
+
+        def ensure_test_model_ready(self) -> None:
+            return None
+
+        def set_dataset(self, _dataset: object) -> None:
+            return None
+
+        def free_model(self) -> None:
+            return None
+
+    class StubDataset:
+        def shuffle(self, *, seed: int) -> "StubDataset":
+            assert seed == 42
+            return self
+
+        def select(self, indices: range) -> "StubDataset":
+            assert list(indices) == [0]
+            return self
+
+        def __len__(self) -> int:
+            return 1
+
+    class StubCustomDataset:
+        has_stereotype = False
+
+        def __init__(
+            self,
+            file_path: str,
+            dataset_type: DatasetType,
+            **_kwargs: Any,
+        ) -> None:
+            assert file_path == "hirundo-io/bloom-gender-ambiguous-bias-free-text"
+            assert dataset_type == DatasetType.BIAS
+
+        def preprocess(self, *_args: Any, **_kwargs: Any) -> StubDataset:
+            return StubDataset()
+
+    monkeypatch.setattr(base_evaluator_module, "TransformersEvalEngine", StubEvalEngine)
+    monkeypatch.setattr(base_evaluator_module, "CustomDataset", StubCustomDataset)
+    monkeypatch.setattr(
+        base_evaluator_module, "DataLoader", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(
+        base_evaluator_module,
+        "empty_cuda_cache_if_available",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        FreeTextBiasEvaluator,
+        "generate",
+        lambda self: [
+            _BiasGenerationRecord(
+                questions=["Who is the engineer?"],
+                answers=["The woman is the engineer."],
+                correct_answers=["the woman"],
+                stereotyped_answers=None,
+                finish_reasons=["stop"],
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        FreeTextBiasEvaluator,
+        "get_judge_engine_context",
+        lambda self: nullcontext(object()),
+    )
+    monkeypatch.setattr(
+        FreeTextBiasEvaluator,
+        "prepare_judge_tokenizer",
+        lambda self: setattr(self, "judge_tokenizer", StubTokenizer()),
+    )
+
+    judge_outputs = iter(
+        [
+            [[{"generated_text": 'gt_agree: "yes"'}]],
+            [[{"generated_text": 'candidate_uncertain: "no"'}]],
+        ]
+    )
+    monkeypatch.setattr(
+        FreeTextBiasEvaluator,
+        "run_judge_with_backoff",
+        lambda self, _judge_engine, _prompts: next(judge_outputs),
+    )
+
+    eval_config = EvaluationConfig(
+        model_path_or_repo_id="fake/model",
+        results_dir=tmp_path,
+        max_samples=1,
+    )
+    dataset_config = DatasetConfig(
+        file_path="hirundo-io/bloom-gender-ambiguous-bias-free-text",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    evaluator = EvaluateFactory.create_evaluator(eval_config, dataset_config)
+
+    assert isinstance(evaluator, FreeTextBiasEvaluator)
+
+    evaluator.evaluate()
+
+    output_dir = (
+        tmp_path / "model" / "bloom-gender-ambiguous-bias-free-text_DatasetType.BIAS"
+    )
+    with (output_dir / "responses.json").open(encoding="utf-8") as responses_file:
+        responses = json.load(responses_file)
+
+    assert responses == [
+        {
+            "question": "Who is the engineer?",
+            "correct_answer": "the woman",
+            "model_answer": "The woman is the engineer.",
+            "judge_gt": 'gt_agree: "yes"',
+            "judge_uncertainty": 'candidate_uncertain: "no"',
+            "flagged_as_correct": True,
+            "flagged_as_stereotyped": False,
+            "flagged_as_unknown": False,
+        }
+    ]
+
+    with (output_dir / "metrics.csv").open(
+        newline="", encoding="utf-8"
+    ) as metrics_file:
+        metrics = list(csv.DictReader(metrics_file))
+
+    assert metrics[0]["Error (%) ⬇️"] == "0.000"
+    assert metrics[0]["Empty Responses"] == "0"


### PR DESCRIPTION
# User description
### Motivation
- Bloom presets previously advertised and supported only `age`, causing `bloom:bias:race`/`gender` to raise `ValueError`; `bloom:...:all` also expanded only to age. 
- The change aims to add `gender` and `race` to Bloom behavior types and update tests/docs so `all` expands across `age`, `gender`, and `race`.

### Description
- Updated `BLOOM_BIAS_TYPES` in `llm_behavior_eval/evaluation_utils/enums.py` to `{"age", "gender", "race"}` and adjusted the Bloom comment to reflect paired bias/unbias splits. 
- Extended `tests/test_bloom.py` to assert concrete dataset IDs for `bloom:bias:gender`, `bloom:unbias:gender`, `bloom:bias:race`, and `bloom:unbias:race`, to validate `bloom:...:all` expansion across all three types, and to adjust the invalid-type assertion. 
- Updated `README.md` examples and summary labels to document Bloom support for `age`, `gender`, and `race`.

### Testing
- Created a virtual environment and installed the package, then ran `pytest` for the Bloom tests with `pytest tests/test_bloom.py`, which reported `5 passed` with warnings. 
- Ran lint checks with `ruff check llm_behavior_eval/evaluation_utils/enums.py tests/test_bloom.py`, which passed with no errors. 
- No other automated test failures were observed during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33ad78ec548333a7ce04cbe16ce0d9)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expand <code>BLOOM_BIAS_TYPES</code> and <code>_behavior_presets</code> so <code>bloom:bias</code>/<code>unbias</code> presets (and <code>all</code>) cover <code>age</code>, <code>gender</code>, and <code>race</code>, plus the new <code>bloom:bias:<type>:ambiguous</code> paths. Document the broader Bloom preset support in <code>README</code> and ensure <code>BaseEvaluator.save_results</code> surfaces the distinct ambiguous summaries with tests verifying dataset slugs, responses, and metrics.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/139?tool=ast&topic=Bloom+presets>Bloom presets</a>
        </td><td>Extend Bloom presets to choose <code>age</code>, <code>gender</code>, and <code>race</code> (including the ambiguous-only bias variants) by updating <code>BLOOM_BIAS_TYPES</code>, handling four-part <code>bloom:bias:<type>:ambiguous</code> behaviors, and exercising the expanded coverage via README guidance and new <code>tests/test_bloom.py</code> assertions.<details><summary>Modified files (4)</summary><ul><li>README.md</li>
<li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/enums.py</li>
<li>tests/test_bloom.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>codex@openai.com</td><td>Add test for ambiguous...</td><td>June 18, 2026</td></tr>
<tr><td>Ilagri</td><td>Trim Bloom README exam...</td><td>June 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/139?tool=ast&topic=Ambiguous+summary>Ambiguous summary</a>
        </td><td>Clarify ambiguous Bloom summaries by mapping ambiguous dataset slugs to <code>Bloom: <type> ambiguous bias</code> inside <code>save_results</code> and covering the end-to-end flow with regression tests that inspect summary rows and generated responses/metrics.<details><summary>Modified files (3)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>tests/test_base_evaluator.py</li>
<li>tests/test_bloom.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>codex@openai.com</td><td>Enhance Bloom evaluati...</td><td>June 18, 2026</td></tr>
<tr><td>Ilagri</td><td>Refine Bloom preset do...</td><td>June 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/139?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>