### PR TITLE
LLM-113: Tighten reviewer approval gate to require a prior human file comment

### DIFF
--- a/.github/workflows/reviewer-approval-gate.yaml
+++ b/.github/workflows/reviewer-approval-gate.yaml
@@ -69,6 +69,7 @@ jobs:
               core.setFailed(`Unable to evaluate PR #${pull_number}: ${error.message}`);
               return;
             }
+            const pullRequestAuthorLogin = pull.user.login;
 
             const reviews = await github.paginate(
               github.rest.pulls.listReviews,
@@ -123,16 +124,30 @@ jobs:
                   per_page: 100,
                 },
               );
-              const approvingReviewerComment = reviewComments.find((comment) =>
-                !isBot(comment.user) && approvingReviewers.has(comment.user?.login),
-              );
+              const [approver] = approvingReviewers;
+              const latestApproval = latestReviewByUser.get(approver);
+              const latestApprovalSubmittedAt = new Date(latestApproval.submitted_at);
+              const humanFileCommentBeforeApproval = reviewComments.some((comment) => {
+                if (isBot(comment.user)) {
+                  return false;
+                }
 
-              if (approvingReviewerComment) {
-                description = "Sole approving reviewer left a file-level review comment.";
+                if (comment.user?.login === pullRequestAuthorLogin) {
+                  return false;
+                }
+
+                if (!latestReviewByUser.has(comment.user?.login)) {
+                  return false;
+                }
+
+                return new Date(comment.created_at) <= latestApprovalSubmittedAt;
+              });
+
+              if (humanFileCommentBeforeApproval) {
+                description = "Human approval followed a human file-level review comment.";
               } else {
-                const [approver] = approvingReviewers;
                 state = "pending";
-                description = `${approver} is the only approver and left no file comments.`;
+                description = "Single approval requires a prior human file comment.";
               }
             }
 


### PR DESCRIPTION
# User description
## Summary
- Update the reviewer approval gate to distinguish human file-level comments from bot activity.
- Allow a sole approval only when it follows a prior human file comment.
- Keep the gate pending when a single approver has not met that condition.

## Testing
- Not run (not requested)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Tighten the reviewer approval gate workflow to require that a lone human approval follows a prior human file-level comment while ignoring bot and author activity. Clarify the commit status messaging so the gate explicitly stays pending until that qualifying human file comment precedes the approval.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/142?tool=ast&topic=Comment+filtering>Comment filtering</a>
        </td><td>Filter review comments by excluding bots and the PR author, capture the author login, and only count commenters with existing review entries when determining valid prior file-level comments.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/reviewer-approval-gate.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Fix last review not ha...</td><td>June 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/142?tool=ast&topic=Sole+approver+gate>Sole approver gate</a>
        </td><td>Enforce reviewer approval gate by checking the sole human approval's timestamp against previous human file comments before marking success.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/reviewer-approval-gate.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>blewis@hirundo.io</td><td>Fix last review not ha...</td><td>June 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/142?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>