### PR TITLE
LLM-115 Fix vLLM dtype selection on T4 GPUs

### DIFF
--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -291,6 +291,17 @@ def pick_best_dtype(device: str, prefer_bf16: bool = True) -> torch.dtype:
     return torch.float32
 
 
+def pick_best_vllm_dtype(device: str, prefer_bf16: bool = True) -> torch.dtype:
+    """Choose the best dtype supported by vLLM on the current device.
+
+    vLLM requires CUDA compute capability 8.0 or newer for bfloat16, while
+    ``torch.cuda.is_bf16_supported()`` can return true on older GPUs.
+    """
+    if device == "cuda" and torch.cuda.get_device_capability() < (8, 0):
+        return torch.float16
+    return pick_best_dtype(device, prefer_bf16=prefer_bf16)
+
+
 def is_model_multimodal(
     repo_id: str, trust_remote_code: bool = False, token: str | None = None
 ) -> bool:

--- a/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
+++ b/llm_behavior_eval/evaluation_utils/vllm_eval_engine.py
@@ -12,7 +12,7 @@ from .util_functions import (
     load_tokenizer_with_transformers,
     load_vllm_model,
     maybe_download_adapter,
-    pick_best_dtype,
+    pick_best_vllm_dtype,
 )
 from .vllm_config import VllmConfig
 
@@ -54,7 +54,7 @@ class VllmEvalEngine(EvalEngine):
         if not self.tokenizer.pad_token:
             self.tokenizer.pad_token = self.tokenizer.eos_token
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        dtype = pick_best_dtype(device)
+        dtype = pick_best_vllm_dtype(device)
         quantization: QuantizationMethods | None = "bitsandbytes" if use_4bit else None
         # Extract vLLM configuration
         vllm_config = eval_config.vllm_config or VllmConfig()

--- a/tests/test_eval_engines.py
+++ b/tests/test_eval_engines.py
@@ -377,6 +377,27 @@ def test_vllm_eval_engine_passes_optional_kwargs(vllm_bundle, tmp_path) -> None:
     assert last_call["load_format"] == "dummy"
 
 
+@pytest.mark.vllm_engine_test
+def test_vllm_eval_engine_uses_float16_on_t4(
+    vllm_bundle, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "llm_behavior_eval.evaluation_utils.vllm_eval_engine.torch.cuda.is_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (7, 5))
+    monkeypatch.setattr(torch.cuda, "is_bf16_supported", lambda: True)
+    config = EvaluationConfig(
+        model_path_or_repo_id="fake/model",
+        results_dir=tmp_path,
+        model_engine="vllm",
+    )
+
+    VllmEvalEngine(config)
+
+    assert vllm_bundle.model_loader.calls[-1]["args"][1] == torch.float16
+
+
 @pytest.mark.transformers_engine_test
 def test_transformers_eval_engine_generate_answers(
     transformers_bundle, tmp_path

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -16,6 +16,7 @@ from llm_behavior_eval.evaluation_utils.util_functions import (
     is_model_multimodal,
     maybe_download_adapter,
     pick_best_dtype,
+    pick_best_vllm_dtype,
     safe_apply_chat_template,
     torch_dtype_to_str,
 )
@@ -71,6 +72,21 @@ def test_pick_best_dtype_cuda_bf16(monkeypatch) -> None:
     monkeypatch.setattr(torch.cuda, "is_bf16_supported", lambda: True)
     dtype = pick_best_dtype("cuda", prefer_bf16=True)
     assert dtype == torch.bfloat16
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected_dtype"),
+    [((7, 5), torch.float16), ((8, 0), torch.bfloat16)],
+)
+def test_pick_best_vllm_dtype_cuda_capability(
+    monkeypatch: pytest.MonkeyPatch,
+    capability: tuple[int, int],
+    expected_dtype: torch.dtype,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: capability)
+    monkeypatch.setattr(torch.cuda, "is_bf16_supported", lambda: True)
+
+    assert pick_best_vllm_dtype("cuda") == expected_dtype
 
 
 def test_safe_apply_chat_template_merges_system_message() -> None:


### PR DESCRIPTION
# User description
Linear: LLM-115

## Summary
- add a vLLM-specific dtype selector that requires CUDA compute capability 8.0+ for bf16
- preserve existing bf16 selection on compatible GPUs and use float16 on T4-class hardware
- add selector coverage for capabilities 7.5 and 8.0 plus a T4 engine regression test

## Validation
- `.venv/bin/python -m pytest -q` — 180 passed
- `.venv/bin/ruff format --check --diff ...` — passed
- `.venv/bin/ruff check ...` — passed
- `.venv/bin/pyrefly check ...` — unable to complete because optional vLLM, MLflow, and GitPython packages are not installed in this macOS environment; diagnostics are limited to missing imports

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a vLLM-specific dtype selector that enforces CUDA 8.0+ for <code>bf16</code> while defaulting to <code>float16</code> on T4 devices so behavior eval can start with Tesla T4 GPUs. Add targeted tests for the selector and the engine regression to confirm dtype choices for CUDA 7.5 vs 8.0+ and guard against passing <code>bf16</code> on unsupported hardware.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/144?tool=ast&topic=vLLM+dtype+selection>vLLM dtype selection</a>
        </td><td>Ensure vLLM path uses <code>pick_best_vllm_dtype</code> so <code>VllmEvalEngine</code> requests <code>float16</code> on T4 (capability &lt; 8.0) while deferring to <code>pick_best_dtype</code> on bf16-capable hardware.<details><summary>Modified files (2)</summary><ul><li>llm_behavior_eval/evaluation_utils/util_functions.py</li>
<li>llm_behavior_eval/evaluation_utils/vllm_eval_engine.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix vLLM dtype selecti...</td><td>July 14, 2026</td></tr>
<tr><td>orr@hirundo.io</td><td>Fix LoRA Adapter Check...</td><td>June 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/144?tool=ast&topic=dtype+regression+tests>dtype regression tests</a>
        </td><td>Validate the new selector by mocking CUDA capabilities and verifying the engine still loads float16 models for T4-class GPUs.<details><summary>Modified files (2)</summary><ul><li>tests/test_eval_engines.py</li>
<li>tests/test_util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix vLLM dtype selecti...</td><td>July 14, 2026</td></tr>
<tr><td>orr@hirundo.io</td><td>Fix LoRA Adapter Check...</td><td>June 16, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/144?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>