### PR TITLE
LLM-118: Accept reasoning kwarg in SafeApplyChatTemplate

### DIFF
--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -83,6 +83,7 @@ class SafeApplyChatTemplate:
         thinking_start_token: str | None = None,
         thinking_end_token: str | None = None,
         pass_max_answer_tokens: bool = False,
+        reasoning: bool | None = None,
     ) -> str:
         """
         Applies the chat template to the messages, ensuring that the system message is handled correctly.
@@ -101,10 +102,15 @@ class SafeApplyChatTemplate:
             thinking_start_token: Thinking start token to use for the model (e.g. '<think>').
             thinking_end_token: Thinking end token to use for the model (e.g. '</think>').
             pass_max_answer_tokens: Whether to pass the max_answer_tokens to the chat template.
+            reasoning: Backward-compatible alias for `enable_thinking`. When provided,
+                this takes precedence over `enable_thinking`.
 
         Returns:
             The formatted string after applying the chat template.
         """
+
+        if reasoning is not None:
+            enable_thinking = reasoning
 
         def _supports_reasoning_kwarg_or_token(
             tokenizer: PreTrainedTokenizerBase, name: str

--- a/llm_behavior_eval/evaluation_utils/util_functions.py
+++ b/llm_behavior_eval/evaluation_utils/util_functions.py
@@ -11,6 +11,7 @@ from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import ParseResult, urlparse
+from weakref import ReferenceType, ref
 
 import torch
 from transformers.models.auto.configuration_auto import AutoConfig
@@ -70,7 +71,9 @@ def _hf_token(token: str | None) -> Generator[None, None, None]:
 
 
 class SafeApplyChatTemplate:
-    _CHAT_TEMPLATE_SUPPORTS_REASONING: dict[tuple[int, str], bool] = {}
+    _CHAT_TEMPLATE_SUPPORTS_REASONING: dict[
+        tuple[int, str], tuple[ReferenceType[PreTrainedTokenizerBase], bool]
+    ] = {}
 
     def __call__(
         self,
@@ -102,8 +105,8 @@ class SafeApplyChatTemplate:
             thinking_start_token: Thinking start token to use for the model (e.g. '<think>').
             thinking_end_token: Thinking end token to use for the model (e.g. '</think>').
             pass_max_answer_tokens: Whether to pass the max_answer_tokens to the chat template.
-            reasoning: Backward-compatible alias for `enable_thinking`. When provided,
-                this takes precedence over `enable_thinking`.
+            reasoning (optional): Backward-compatible alias for `enable_thinking`.
+                When provided, this takes precedence over `enable_thinking`.
 
         Returns:
             The formatted string after applying the chat template.
@@ -125,18 +128,20 @@ class SafeApplyChatTemplate:
             Returns:
                 True if the tokenizer's apply_chat_template supports the reasoning mode kwarg `name` or the token `name`, False otherwise.
             """
-            # Cache for checking whether a given tokenizer's apply_chat_template supports
-            # the reasoning mode kwarg `name` or the token `name`. Keyed by (id(tokenizer), name) to avoid holding strong refs.
-            # This avoids repeated try/except in hot paths.
+            # Key by object ID without retaining tokenizers, and validate identity to
+            # avoid stale results when Python reuses an ID after garbage collection.
             cache_key = (id(tokenizer), name)
             cached = self._CHAT_TEMPLATE_SUPPORTS_REASONING.get(cache_key)
-            if cached is not None:
-                return cached
+            if cached is not None and cached[0]() is tokenizer:
+                return cached[1]
             supports = (
                 isinstance(tokenizer.chat_template, str)
                 and name in tokenizer.chat_template
             )
-            self._CHAT_TEMPLATE_SUPPORTS_REASONING[cache_key] = supports
+            self._CHAT_TEMPLATE_SUPPORTS_REASONING[cache_key] = (
+                ref(tokenizer),
+                supports,
+            )
 
             return supports
 

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
+from weakref import ref
 
 import pytest
 import torch
@@ -61,6 +62,26 @@ class StubTokenizer:
         # Simple join of role and content for testing purposes
         return "|".join(
             f"{message['role']}:{message['content']}" for message in messages
+        )
+
+
+class ReasoningTokenizer(StubTokenizer):
+    def __init__(self) -> None:
+        super().__init__("Qwen/Qwen3-0.6B", "{{ enable_thinking }}")
+        self.enable_thinking: bool | None = None
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    ):
+        self.enable_thinking = enable_thinking
+        return super().apply_chat_template(
+            messages,
+            tokenize=tokenize,
+            add_generation_prompt=add_generation_prompt,
         )
 
 
@@ -152,25 +173,6 @@ def test_safe_apply_chat_template_does_not_append_without_flag_or_value() -> Non
 def test_safe_apply_chat_template_accepts_reasoning_alias(
     enable_thinking: bool, reasoning: bool | None, expected: bool
 ) -> None:
-    class ReasoningTokenizer(StubTokenizer):
-        def __init__(self) -> None:
-            super().__init__("Qwen/Qwen3-0.6B", "{{ enable_thinking }}")
-            self.enable_thinking: bool | None = None
-
-        def apply_chat_template(
-            self,
-            messages,
-            tokenize=False,
-            add_generation_prompt=True,
-            enable_thinking=False,
-        ):
-            self.enable_thinking = enable_thinking
-            return super().apply_chat_template(
-                messages,
-                tokenize=tokenize,
-                add_generation_prompt=add_generation_prompt,
-            )
-
     tokenizer = ReasoningTokenizer()
 
     safe_apply_chat_template(
@@ -181,6 +183,27 @@ def test_safe_apply_chat_template_accepts_reasoning_alias(
     )
 
     assert tokenizer.enable_thinking is expected
+
+
+def test_safe_apply_chat_template_ignores_stale_cache_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_tokenizer = StubTokenizer("stale/model", "generic template")
+    tokenizer = ReasoningTokenizer()
+    cache_key = (id(tokenizer), "enable_thinking")
+    monkeypatch.setitem(
+        safe_apply_chat_template._CHAT_TEMPLATE_SUPPORTS_REASONING,
+        cache_key,
+        (ref(cast("PreTrainedTokenizerBase", stale_tokenizer)), False),
+    )
+
+    safe_apply_chat_template(
+        cast("PreTrainedTokenizerBase", tokenizer),
+        [{"role": "user", "content": "Hello"}],
+        reasoning=True,
+    )
+
+    assert tokenizer.enable_thinking is True
 
 
 def test_torch_dtype_to_str_supported() -> None:

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -140,6 +140,49 @@ def test_safe_apply_chat_template_does_not_append_without_flag_or_value() -> Non
     assert "Respond in no more than" not in without_value
 
 
+@pytest.mark.parametrize(
+    ("enable_thinking", "reasoning", "expected"),
+    [
+        (False, False, False),
+        (False, True, True),
+        (True, False, False),
+        (True, None, True),
+    ],
+)
+def test_safe_apply_chat_template_accepts_reasoning_alias(
+    enable_thinking: bool, reasoning: bool | None, expected: bool
+) -> None:
+    class ReasoningTokenizer(StubTokenizer):
+        def __init__(self) -> None:
+            super().__init__("Qwen/Qwen3-0.6B", "{{ enable_thinking }}")
+            self.enable_thinking: bool | None = None
+
+        def apply_chat_template(
+            self,
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        ):
+            self.enable_thinking = enable_thinking
+            return super().apply_chat_template(
+                messages,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+            )
+
+    tokenizer = ReasoningTokenizer()
+
+    safe_apply_chat_template(
+        cast("PreTrainedTokenizerBase", tokenizer),
+        [{"role": "user", "content": "Hello"}],
+        enable_thinking=enable_thinking,
+        reasoning=reasoning,
+    )
+
+    assert tokenizer.enable_thinking is expected
+
+
 def test_torch_dtype_to_str_supported() -> None:
     assert torch_dtype_to_str(torch.float16) == "float16"
     assert torch_dtype_to_str(torch.bfloat16) == "bfloat16"


### PR DESCRIPTION
# User description
## Summary

- add `reasoning` as a backward-compatible alias for `enable_thinking`
- give the explicitly supplied alias precedence when both arguments are present
- cover Qwen-style forwarding, precedence, and unchanged existing behavior

Linear: LLM-118

## Validation

- `.venv/bin/python -m pytest tests/test_util_functions.py -q` (56 passed)
- `.venv/bin/python -m pytest -q` (184 passed)
- `uvx ruff@0.14.10 format --check --diff .`
- `uvx ruff@0.14.10 check .`
- `pyrefly check` attempted; blocked by unavailable optional `vllm`, MLflow, and GitPython imports in the macOS-compatible base environment

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a backward-compatible <code>reasoning</code> argument to <code>SafeApplyChatTemplate</code> so preprocessing callers can request thinking mode without breaking existing <code>enable_thinking</code> usage. Ensure <code>reasoning</code> wins over <code>enable_thinking</code> and keep the tokenizer reasoning support cache accurate via weak refs to prevent stale entries.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/148?tool=ast&topic=Reasoning+alias>Reasoning alias</a>
        </td><td>Add reasoning alias handling to <code>SafeApplyChatTemplate</code>, letting it override <code>enable_thinking</code> and caching tokenizer support with weak refs to avoid stale entries.<details><summary>Modified files (1)</summary><ul><li>llm_behavior_eval/evaluation_utils/util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix reasoning cache is...</td><td>July 15, 2026</td></tr>
<tr><td>orr@hirundo.io</td><td>Fix LoRA Adapter Check...</td><td>June 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/148?tool=ast&topic=Reasoning+tests>Reasoning tests</a>
        </td><td>Add coverage for alias precedence and stale cache handling via new <code>ReasoningTokenizer</code> tests.<details><summary>Modified files (1)</summary><ul><li>tests/test_util_functions.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix reasoning cache is...</td><td>July 15, 2026</td></tr>
<tr><td>orr@hirundo.io</td><td>Fix LoRA Adapter Check...</td><td>June 16, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/148?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>