### PR TITLE
LLM-119: Validate generation alignment across free-text evaluators

### DIFF
--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -7,7 +7,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager, contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, cast
@@ -464,6 +464,18 @@ class BaseEvaluator(ABC):
                 f"expected aligned fields, got {details}."
             )
 
+    def validate_generation_record(
+        self, generation: _GenerationRecord, *, context: str
+    ) -> None:
+        self.validate_generation_alignment(
+            {
+                field.name: value
+                for field in fields(generation)
+                if isinstance((value := getattr(generation, field.name)), list)
+            },
+            context=context,
+        )
+
     def load_aligned_generation_dicts(
         self,
         required_fields: Sequence[str],
@@ -476,40 +488,24 @@ class BaseEvaluator(ABC):
         valid_prefix: list[dict] = []
         for batch_index, item in enumerate(completed_dicts):
             fields: dict[str, Sequence[object]] = {}
-            invalid_field = next(
-                (
-                    name
-                    for name in required_fields
-                    if not isinstance(item.get(name), list)
-                ),
-                None,
-            )
-            if invalid_field is None:
-                invalid_field = next(
-                    (
-                        name
-                        for name in optional_fields
-                        if name in item
-                        and item[name] is not None
-                        and not isinstance(item[name], list)
-                    ),
-                    None,
-                )
-            if invalid_field is None:
-                fields.update({name: item[name] for name in required_fields})
-                fields.update(
-                    {
-                        name: item[name]
-                        for name in optional_fields
-                        if isinstance(item.get(name), list)
-                    }
-                )
             try:
-                if invalid_field is not None:
-                    raise ValueError(
-                        f"Generation record is incomplete (cached batch {batch_index}): "
-                        f"expected {invalid_field} to be a list."
-                    )
+                for name in required_fields:
+                    if not isinstance(item.get(name), list):
+                        raise ValueError(
+                            f"Generation record is incomplete (cached batch {batch_index}): "
+                            f"expected {name} to be a list."
+                        )
+                    fields[name] = item[name]
+                for name in optional_fields:
+                    value = item.get(name)
+                    if value is not None:
+                        if not isinstance(value, list):
+                            raise ValueError(
+                                f"Generation record is incomplete "
+                                f"(cached batch {batch_index}): "
+                                f"expected {name} to be a list."
+                            )
+                        fields[name] = value
                 self.validate_generation_alignment(
                     fields, context=f"cached batch {batch_index}"
                 )

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -464,7 +464,7 @@ class BaseEvaluator(ABC):
                 f"expected aligned fields, got {details}."
             )
 
-    def validate_generation_record(
+    def _validate_generation_record(
         self, generation: _GenerationRecord, *, context: str
     ) -> None:
         self.validate_generation_alignment(

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -311,7 +311,7 @@ class BaseEvaluator(ABC):
         attention_mask: torch.Tensor,
         do_sample: bool | None = None,
     ) -> tuple[list[str], list[str | None]]:
-        return self.eval_engine.generate_answers(
+        answers, finish_reasons = self.eval_engine.generate_answers(
             input_ids,
             attention_mask,
             sampling_config=SamplingConfig(
@@ -328,6 +328,15 @@ class BaseEvaluator(ABC):
                 seed=self.dataset_config.seed or self.eval_config.sampling_config.seed,
             ),
         )
+        self.validate_generation_alignment(
+            {
+                "prompts": range(input_ids.shape[0]),
+                "answers": answers,
+                "finish_reasons": finish_reasons,
+            },
+            context="test-model generation",
+        )
+        return answers, finish_reasons
 
     @abstractmethod
     def evaluate(self) -> None:
@@ -442,6 +451,75 @@ class BaseEvaluator(ABC):
             self.generations_path(filename),
         )
         return existing_generations
+
+    @staticmethod
+    def validate_generation_alignment(
+        fields: dict[str, Sequence[object]], *, context: str
+    ) -> None:
+        lengths = {name: len(values) for name, values in fields.items()}
+        if len(set(lengths.values())) != 1:
+            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
+            raise ValueError(
+                f"Generation record is incomplete ({context}): "
+                f"expected aligned fields, got {details}."
+            )
+
+    def load_aligned_generation_dicts(
+        self,
+        required_fields: Sequence[str],
+        *,
+        optional_fields: Sequence[str] = (),
+        filename: str = "generations.jsonl",
+    ) -> list[dict]:
+        """Load the longest valid cached prefix and discard incomplete later batches."""
+        completed_dicts = self.load_completed_generation_dicts(filename)
+        valid_prefix: list[dict] = []
+        for batch_index, item in enumerate(completed_dicts):
+            fields: dict[str, Sequence[object]] = {}
+            invalid_field = next(
+                (
+                    name
+                    for name in required_fields
+                    if not isinstance(item.get(name), list)
+                ),
+                None,
+            )
+            if invalid_field is None:
+                invalid_field = next(
+                    (
+                        name
+                        for name in optional_fields
+                        if name in item
+                        and item[name] is not None
+                        and not isinstance(item[name], list)
+                    ),
+                    None,
+                )
+            if invalid_field is None:
+                fields.update({name: item[name] for name in required_fields})
+                fields.update(
+                    {
+                        name: item[name]
+                        for name in optional_fields
+                        if isinstance(item.get(name), list)
+                    }
+                )
+            try:
+                if invalid_field is not None:
+                    raise ValueError(
+                        f"Generation record is incomplete (cached batch {batch_index}): "
+                        f"expected {invalid_field} to be a list."
+                    )
+                self.validate_generation_alignment(
+                    fields, context=f"cached batch {batch_index}"
+                )
+            except ValueError as error:
+                logging.warning("%s Regenerating this and subsequent batches.", error)
+                self.reset_generations_file(filename)
+                self.save_generations(valid_prefix, filename)
+                break
+            valid_prefix.append(item)
+        return valid_prefix
 
     def _get_incomplete_response_rate(self) -> float | None:
         generations = self.load_generations()
@@ -1287,6 +1365,14 @@ class FreeTextSharedEvaluator(BaseEvaluator):
                 top_k=self.eval_config.sampling_config.top_k,
                 seed=self.dataset_config.seed or self.eval_config.sampling_config.seed,
             ),
+        )
+        self.validate_generation_alignment(
+            {
+                "prompts": prompts,
+                "answers": answers,
+                "finish_reasons": finish_reasons,
+            },
+            context="judge-model generation",
         )
 
         # Format output to match pipeline format per prompt.

--- a/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
@@ -81,19 +81,6 @@ class _BiasGenerationRecord(_GenerationRecord):
 
 
 class FreeTextBiasEvaluator(FreeTextSharedEvaluator):
-    def _validate_generation_record(
-        self, generation: _BiasGenerationRecord, *, context: str
-    ) -> None:
-        fields = {
-            "questions": generation.questions,
-            "answers": generation.answers,
-            "correct_answers": generation.correct_answers,
-            "finish_reasons": generation.finish_reasons,
-        }
-        if generation.stereotyped_answers is not None:
-            fields["stereotyped_answers"] = generation.stereotyped_answers
-        self.validate_generation_alignment(fields, context=context)
-
     AGREEMENT_CHECK_SYSTEM_PROMPT = """
 You will receive three texts:
 
@@ -225,7 +212,7 @@ candidate_uncertain: "<yes|no>"
                 stereotyped_answers=stereotyped_answers_text,
                 finish_reasons=finish_reasons,
             )
-            self._validate_generation_record(
+            self.validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generation_records.append(generation_record)
@@ -377,7 +364,7 @@ candidate_uncertain: "<yes|no>"
             desc="Grading responses",
             unit="batch",
         ):
-            self._validate_generation_record(generation_record, context="grading")
+            self.validate_generation_record(generation_record, context="grading")
             answers = self._format_answers(generation_record.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
@@ -81,6 +81,19 @@ class _BiasGenerationRecord(_GenerationRecord):
 
 
 class FreeTextBiasEvaluator(FreeTextSharedEvaluator):
+    def _validate_generation_record(
+        self, generation: _BiasGenerationRecord, *, context: str
+    ) -> None:
+        fields = {
+            "questions": generation.questions,
+            "answers": generation.answers,
+            "correct_answers": generation.correct_answers,
+            "finish_reasons": generation.finish_reasons,
+        }
+        if generation.stereotyped_answers is not None:
+            fields["stereotyped_answers"] = generation.stereotyped_answers
+        self.validate_generation_alignment(fields, context=context)
+
     AGREEMENT_CHECK_SYSTEM_PROMPT = """
 You will receive three texts:
 
@@ -161,7 +174,10 @@ candidate_uncertain: "<yes|no>"
 
     def _collect_generations(self) -> list[_BiasGenerationRecord]:
         self.ensure_test_model_ready()
-        completed_dicts = self.load_completed_generation_dicts()
+        completed_dicts = self.load_aligned_generation_dicts(
+            ("questions", "answers", "correct_answers", "finish_reasons"),
+            optional_fields=("stereotyped_answers",),
+        )
         completed_generations = [
             _BiasGenerationRecord(
                 questions=item.get("questions", []),
@@ -208,6 +224,9 @@ candidate_uncertain: "<yes|no>"
                 correct_answers=correct_answers_text,
                 stereotyped_answers=stereotyped_answers_text,
                 finish_reasons=finish_reasons,
+            )
+            self._validate_generation_record(
+                generation_record, context=f"fresh batch {batch_index}"
             )
             generation_records.append(generation_record)
             self.save_generations(
@@ -358,6 +377,7 @@ candidate_uncertain: "<yes|no>"
             desc="Grading responses",
             unit="batch",
         ):
+            self._validate_generation_record(generation_record, context="grading")
             answers = self._format_answers(generation_record.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py
@@ -212,7 +212,7 @@ candidate_uncertain: "<yes|no>"
                 stereotyped_answers=stereotyped_answers_text,
                 finish_reasons=finish_reasons,
             )
-            self.validate_generation_record(
+            self._validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generation_records.append(generation_record)
@@ -364,7 +364,7 @@ candidate_uncertain: "<yes|no>"
             desc="Grading responses",
             unit="batch",
         ):
-            self.validate_generation_record(generation_record, context="grading")
+            self._validate_generation_record(generation_record, context="grading")
             answers = self._format_answers(generation_record.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
@@ -38,6 +38,19 @@ class _HalluGenerationRecord(_GenerationRecord):
 
 
 class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
+    def _validate_generation_record(
+        self, generation: _HalluGenerationRecord, *, context: str
+    ) -> None:
+        self.validate_generation_alignment(
+            {
+                "input_texts": generation.input_texts,
+                "gt_answers": generation.gt_answers,
+                "answers": generation.answers,
+                "finish_reasons": generation.finish_reasons,
+            },
+            context=context,
+        )
+
     @staticmethod
     def _map_judge_outputs(
         judge_raw: Sequence[Sequence[Mapping[str, str | None]]],
@@ -55,7 +68,9 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
 
     def _collect_generations(self) -> Sequence[_HalluGenerationRecord]:
         self.ensure_test_model_ready()
-        completed_dicts = self.load_completed_generation_dicts()
+        completed_dicts = self.load_aligned_generation_dicts(
+            ("input_texts", "gt_answers", "answers", "finish_reasons")
+        )
         completed_generations = [
             _HalluGenerationRecord(
                 input_texts=item.get("input_texts", []),
@@ -95,6 +110,9 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
                 gt_answers=gt_answers,
                 answers=answers,
                 finish_reasons=finish_reasons,
+            )
+            self._validate_generation_record(
+                generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
             self.save_generations(
@@ -179,6 +197,7 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
@@ -38,19 +38,6 @@ class _HalluGenerationRecord(_GenerationRecord):
 
 
 class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
-    def _validate_generation_record(
-        self, generation: _HalluGenerationRecord, *, context: str
-    ) -> None:
-        self.validate_generation_alignment(
-            {
-                "input_texts": generation.input_texts,
-                "gt_answers": generation.gt_answers,
-                "answers": generation.answers,
-                "finish_reasons": generation.finish_reasons,
-            },
-            context=context,
-        )
-
     @staticmethod
     def _map_judge_outputs(
         judge_raw: Sequence[Sequence[Mapping[str, str | None]]],
@@ -111,7 +98,7 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self._validate_generation_record(
+            self.validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
@@ -197,7 +184,7 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self._validate_generation_record(generation, context="grading")
+            self.validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py
@@ -98,7 +98,7 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self.validate_generation_record(
+            self._validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
@@ -184,7 +184,7 @@ class FreeTextHaluEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self.validate_generation_record(generation, context="grading")
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -41,14 +41,20 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
     ).strip()
 
     @staticmethod
-    def _generation_from_dict(item: Mapping) -> _InjectionGenerationRecord:
-        input_texts = cast("list[str]", item.get("input_texts", []))
+    def _generation_from_dict(
+        generation_dict: Mapping,
+    ) -> _InjectionGenerationRecord:
+        input_texts = cast("list[str]", generation_dict.get("input_texts", []))
         return _InjectionGenerationRecord(
             input_texts=input_texts,
-            judge_questions=cast("list[str]", item.get("judge_questions", input_texts)),
-            gt_answers=cast("list[str]", item.get("gt_answers", [])),
-            answers=cast("list[str]", item.get("answers", [])),
-            finish_reasons=cast("list[str | None]", item.get("finish_reasons", [])),
+            judge_questions=cast(
+                "list[str]", generation_dict.get("judge_questions", input_texts)
+            ),
+            gt_answers=cast("list[str]", generation_dict.get("gt_answers", [])),
+            answers=cast("list[str]", generation_dict.get("answers", [])),
+            finish_reasons=cast(
+                "list[str | None]", generation_dict.get("finish_reasons", [])
+            ),
         )
 
     @staticmethod
@@ -100,7 +106,8 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             optional_fields=("judge_questions",),
         )
         completed_generations = [
-            self._generation_from_dict(item) for item in completed_dicts
+            self._generation_from_dict(generation_dict)
+            for generation_dict in completed_dicts
         ]
         completed_samples = sum(
             len(generation.input_texts) for generation in completed_generations

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -39,6 +40,45 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
       Answer in one word Yes or No:
       """
     ).strip()
+
+    @staticmethod
+    def _validate_generation_record(
+        generation: _InjectionGenerationRecord, *, context: str
+    ) -> None:
+        lengths = {
+            "input_texts": len(generation.input_texts),
+            "judge_questions": len(generation.judge_questions),
+            "gt_answers": len(generation.gt_answers),
+            "answers": len(generation.answers),
+            "finish_reasons": len(generation.finish_reasons),
+        }
+        if len(set(lengths.values())) != 1:
+            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
+            raise ValueError(
+                f"Prompt-injection generation record is incomplete ({context}): "
+                f"expected aligned fields, got {details}."
+            )
+
+    @staticmethod
+    def _generation_dict(generation: _InjectionGenerationRecord) -> dict:
+        return {
+            "input_texts": generation.input_texts,
+            "judge_questions": generation.judge_questions,
+            "gt_answers": generation.gt_answers,
+            "answers": generation.answers,
+            "finish_reasons": generation.finish_reasons,
+        }
+
+    @staticmethod
+    def _generation_from_dict(item: Mapping) -> _InjectionGenerationRecord:
+        input_texts = cast("list[str]", item.get("input_texts", []))
+        return _InjectionGenerationRecord(
+            input_texts=input_texts,
+            judge_questions=cast("list[str]", item.get("judge_questions", input_texts)),
+            gt_answers=cast("list[str]", item.get("gt_answers", [])),
+            answers=cast("list[str]", item.get("answers", [])),
+            finish_reasons=cast("list[str | None]", item.get("finish_reasons", [])),
+        )
 
     @staticmethod
     def _map_judge_outputs_yes_no(
@@ -85,19 +125,23 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
     ) -> Sequence[_InjectionGenerationRecord]:  # include judge_questions from dataset
         self.ensure_test_model_ready()
         completed_dicts = self.load_completed_generation_dicts()
-        completed_generations = [
-            _InjectionGenerationRecord(
-                input_texts=cast("list[str]", item.get("input_texts", [])),
-                judge_questions=cast(
-                    "list[str]",
-                    item.get("judge_questions", item.get("input_texts", [])),
-                ),
-                gt_answers=cast("list[str]", item.get("gt_answers", [])),
-                answers=cast("list[str]", item.get("answers", [])),
-                finish_reasons=cast("list[str | None]", item.get("finish_reasons", [])),
-            )
-            for item in completed_dicts
+        loaded_generations = [
+            self._generation_from_dict(item) for item in completed_dicts
         ]
+        completed_generations: list[_InjectionGenerationRecord] = []
+        for batch_index, generation in enumerate(loaded_generations):
+            try:
+                self._validate_generation_record(
+                    generation, context=f"cached batch {batch_index}"
+                )
+            except ValueError as error:
+                logging.warning("%s Regenerating this and subsequent batches.", error)
+                self.reset_generations_file()
+                self.save_generations(
+                    [self._generation_dict(item) for item in completed_generations]
+                )
+                break
+            completed_generations.append(generation)
         completed_samples = sum(
             len(generation.input_texts) for generation in completed_generations
         )
@@ -137,18 +181,11 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            generations.append(generation_record)
-            self.save_generations(
-                [
-                    {
-                        "input_texts": generation_record.input_texts,
-                        "judge_questions": generation_record.judge_questions,
-                        "gt_answers": generation_record.gt_answers,
-                        "answers": generation_record.answers,
-                        "finish_reasons": generation_record.finish_reasons,
-                    }
-                ]
+            self._validate_generation_record(
+                generation_record, context=f"fresh batch {batch_index}"
             )
+            generations.append(generation_record)
+            self.save_generations([self._generation_dict(generation_record)])
 
             remaining -= len(input_texts)
             if remaining <= 0:
@@ -191,6 +228,7 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -41,23 +40,20 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
       """
     ).strip()
 
-    @staticmethod
     def _validate_generation_record(
-        generation: _InjectionGenerationRecord, *, context: str
+        self, generation: _HalluGenerationRecord, *, context: str
     ) -> None:
-        lengths = {
-            "input_texts": len(generation.input_texts),
-            "judge_questions": len(generation.judge_questions),
-            "gt_answers": len(generation.gt_answers),
-            "answers": len(generation.answers),
-            "finish_reasons": len(generation.finish_reasons),
-        }
-        if len(set(lengths.values())) != 1:
-            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
-            raise ValueError(
-                f"Prompt-injection generation record is incomplete ({context}): "
-                f"expected aligned fields, got {details}."
-            )
+        injection_generation = cast("_InjectionGenerationRecord", generation)
+        self.validate_generation_alignment(
+            {
+                "input_texts": injection_generation.input_texts,
+                "judge_questions": injection_generation.judge_questions,
+                "gt_answers": injection_generation.gt_answers,
+                "answers": injection_generation.answers,
+                "finish_reasons": injection_generation.finish_reasons,
+            },
+            context=context,
+        )
 
     @staticmethod
     def _generation_dict(generation: _InjectionGenerationRecord) -> dict:
@@ -124,24 +120,14 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
         self,
     ) -> Sequence[_InjectionGenerationRecord]:  # include judge_questions from dataset
         self.ensure_test_model_ready()
-        completed_dicts = self.load_completed_generation_dicts()
+        completed_dicts = self.load_aligned_generation_dicts(
+            ("input_texts", "gt_answers", "answers", "finish_reasons"),
+            optional_fields=("judge_questions",),
+        )
         loaded_generations = [
             self._generation_from_dict(item) for item in completed_dicts
         ]
-        completed_generations: list[_InjectionGenerationRecord] = []
-        for batch_index, generation in enumerate(loaded_generations):
-            try:
-                self._validate_generation_record(
-                    generation, context=f"cached batch {batch_index}"
-                )
-            except ValueError as error:
-                logging.warning("%s Regenerating this and subsequent batches.", error)
-                self.reset_generations_file()
-                self.save_generations(
-                    [self._generation_dict(item) for item in completed_generations]
-                )
-                break
-            completed_generations.append(generation)
+        completed_generations = loaded_generations
         completed_samples = sum(
             len(generation.input_texts) for generation in completed_generations
         )

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -148,7 +148,7 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self.validate_generation_record(
+            self._validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
@@ -205,7 +205,7 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self.validate_generation_record(generation, context="grading")
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py
@@ -40,31 +40,6 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
       """
     ).strip()
 
-    def _validate_generation_record(
-        self, generation: _HalluGenerationRecord, *, context: str
-    ) -> None:
-        injection_generation = cast("_InjectionGenerationRecord", generation)
-        self.validate_generation_alignment(
-            {
-                "input_texts": injection_generation.input_texts,
-                "judge_questions": injection_generation.judge_questions,
-                "gt_answers": injection_generation.gt_answers,
-                "answers": injection_generation.answers,
-                "finish_reasons": injection_generation.finish_reasons,
-            },
-            context=context,
-        )
-
-    @staticmethod
-    def _generation_dict(generation: _InjectionGenerationRecord) -> dict:
-        return {
-            "input_texts": generation.input_texts,
-            "judge_questions": generation.judge_questions,
-            "gt_answers": generation.gt_answers,
-            "answers": generation.answers,
-            "finish_reasons": generation.finish_reasons,
-        }
-
     @staticmethod
     def _generation_from_dict(item: Mapping) -> _InjectionGenerationRecord:
         input_texts = cast("list[str]", item.get("input_texts", []))
@@ -124,10 +99,9 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             ("input_texts", "gt_answers", "answers", "finish_reasons"),
             optional_fields=("judge_questions",),
         )
-        loaded_generations = [
+        completed_generations = [
             self._generation_from_dict(item) for item in completed_dicts
         ]
-        completed_generations = loaded_generations
         completed_samples = sum(
             len(generation.input_texts) for generation in completed_generations
         )
@@ -167,11 +141,21 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self._validate_generation_record(
+            self.validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
-            self.save_generations([self._generation_dict(generation_record)])
+            self.save_generations(
+                [
+                    {
+                        "input_texts": generation_record.input_texts,
+                        "judge_questions": generation_record.judge_questions,
+                        "gt_answers": generation_record.gt_answers,
+                        "answers": generation_record.answers,
+                        "finish_reasons": generation_record.finish_reasons,
+                    }
+                ]
+            )
 
             remaining -= len(input_texts)
             if remaining <= 0:
@@ -214,7 +198,7 @@ class FreeTextPromptInjectionEvaluator(FreeTextHaluEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self._validate_generation_record(generation, context="grading")
+            self.validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
@@ -110,19 +110,6 @@ class _RefusalGenerationRecord(_GenerationRecord):
 
 
 class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
-    def _validate_generation_record(
-        self, generation: _RefusalGenerationRecord, *, context: str
-    ) -> None:
-        self.validate_generation_alignment(
-            {
-                "input_texts": generation.input_texts,
-                "expected_labels": generation.expected_labels,
-                "answers": generation.answers,
-                "finish_reasons": generation.finish_reasons,
-            },
-            context=context,
-        )
-
     def generate(self) -> Sequence[_GenerationRecord]:
         with torch.inference_mode():
             generations = self._collect_generations()
@@ -193,7 +180,7 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self._validate_generation_record(
+            self.validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
@@ -437,7 +424,7 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self._validate_generation_record(generation, context="grading")
+            self.validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
@@ -110,6 +110,19 @@ class _RefusalGenerationRecord(_GenerationRecord):
 
 
 class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
+    def _validate_generation_record(
+        self, generation: _RefusalGenerationRecord, *, context: str
+    ) -> None:
+        self.validate_generation_alignment(
+            {
+                "input_texts": generation.input_texts,
+                "expected_labels": generation.expected_labels,
+                "answers": generation.answers,
+                "finish_reasons": generation.finish_reasons,
+            },
+            context=context,
+        )
+
     def generate(self) -> Sequence[_GenerationRecord]:
         with torch.inference_mode():
             generations = self._collect_generations()
@@ -140,7 +153,9 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
 
     def _collect_generations(self) -> Sequence[_RefusalGenerationRecord]:
         self.ensure_test_model_ready()
-        completed_dicts = self.load_completed_generation_dicts()
+        completed_dicts = self.load_aligned_generation_dicts(
+            ("input_texts", "expected_labels", "answers", "finish_reasons")
+        )
         completed_generations = [
             _RefusalGenerationRecord(
                 input_texts=cast("list[str]", item.get("input_texts", [])),
@@ -177,6 +192,9 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
                 expected_labels=expected_labels,
                 answers=answers,
                 finish_reasons=finish_reasons,
+            )
+            self._validate_generation_record(
+                generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
             self.save_generations(
@@ -419,6 +437,7 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
@@ -180,7 +180,7 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
                 answers=answers,
                 finish_reasons=finish_reasons,
             )
-            self.validate_generation_record(
+            self._validate_generation_record(
                 generation_record, context=f"fresh batch {batch_index}"
             )
             generations.append(generation_record)
@@ -424,7 +424,7 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
             desc="Grading responses",
             unit="batch",
         ):
-            self.validate_generation_record(generation, context="grading")
+            self._validate_generation_record(generation, context="grading")
             answers = self._format_answers(generation.answers)
             judge_indices = [
                 idx

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -546,6 +546,80 @@ def test_process_judge_prompts_rejects_short_judge_output(tmp_path: Path) -> Non
         )
 
 
+@pytest.mark.parametrize(
+    ("invalid_field", "invalid_value", "optional_fields"),
+    [
+        ("answers", "not-a-list", ()),
+        ("metadata", "not-a-list", ("metadata",)),
+    ],
+)
+def test_load_aligned_generation_dicts_rejects_non_list_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_field: str,
+    invalid_value: str,
+    optional_fields: tuple[str, ...],
+) -> None:
+    evaluator = ConcreteEvaluator.__new__(ConcreteEvaluator)
+    generation = {"prompts": ["prompt"], "answers": ["answer"]}
+    generation[invalid_field] = invalid_value
+    reset_filenames: list[str] = []
+    saved: list[tuple[list[dict], str]] = []
+    monkeypatch.setattr(
+        evaluator,
+        "load_completed_generation_dicts",
+        lambda _filename: [generation],
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "reset_generations_file",
+        lambda filename: reset_filenames.append(filename),
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "save_generations",
+        lambda items, filename: saved.append((items, filename)),
+    )
+
+    result = evaluator.load_aligned_generation_dicts(
+        ("prompts", "answers"), optional_fields=optional_fields
+    )
+
+    assert result == []
+    assert reset_filenames == ["generations.jsonl"]
+    assert saved == [([], "generations.jsonl")]
+
+
+def test_load_aligned_generation_dicts_preserves_valid_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator = ConcreteEvaluator.__new__(ConcreteEvaluator)
+    valid = {"prompts": ["one"], "answers": ["answer one"]}
+    incomplete = {"prompts": ["two", "three"], "answers": ["answer two"]}
+    reset_filenames: list[str] = []
+    saved: list[tuple[list[dict], str]] = []
+    monkeypatch.setattr(
+        evaluator,
+        "load_completed_generation_dicts",
+        lambda _filename: [valid, incomplete],
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "reset_generations_file",
+        lambda filename: reset_filenames.append(filename),
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "save_generations",
+        lambda items, filename: saved.append((items, filename)),
+    )
+
+    result = evaluator.load_aligned_generation_dicts(("prompts", "answers"))
+
+    assert result == [valid]
+    assert reset_filenames == ["generations.jsonl"]
+    assert saved == [([valid], "generations.jsonl")]
+
+
 def test_get_model_slug_includes_lora_slug(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -471,6 +471,81 @@ def test_process_judge_prompts_batch_uses_sampling_config(tmp_path: Path) -> Non
     assert sampling_config.seed == evaluator.dataset_config.seed
 
 
+def test_generate_answers_rejects_short_test_model_output(tmp_path: Path) -> None:
+    evaluator = ConcreteEvaluator.__new__(ConcreteEvaluator)
+    evaluator.eval_config = EvaluationConfig(
+        model_path_or_repo_id="meta/model",
+        results_dir=tmp_path,
+    )
+    evaluator.dataset_config = DatasetConfig(
+        file_path="repo/dataset",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    class ShortEngine:
+        @staticmethod
+        def generate_answers(*_args, **_kwargs):
+            return ["only one"], ["stop"]
+
+    evaluator.eval_engine = cast("EvalEngine", ShortEngine())
+    input_ids = torch.tensor([[10], [11]])
+
+    with pytest.raises(
+        ValueError,
+        match=r"test-model generation.*prompts=2.*answers=1.*finish_reasons=1",
+    ):
+        evaluator.generate_answers(input_ids, torch.ones_like(input_ids))
+
+
+def test_process_judge_prompts_rejects_short_judge_output(tmp_path: Path) -> None:
+    class StubFreeTextEvaluator(FreeTextSharedEvaluator):
+        def evaluate(self) -> None:
+            return None
+
+        def generate(self) -> Sequence[_GenerationRecord]:
+            return []
+
+        def _grade_impl(self, generations: object, judge_engine: object = None) -> None:
+            del generations, judge_engine
+
+        def get_grading_context(self) -> AbstractContextManager:
+            return nullcontext()
+
+    evaluator = StubFreeTextEvaluator.__new__(StubFreeTextEvaluator)
+    evaluator.eval_config = EvaluationConfig(
+        model_path_or_repo_id="meta/model",
+        results_dir=tmp_path,
+    )
+    evaluator.dataset_config = DatasetConfig(
+        file_path="repo/dataset",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    class TwoPromptTokenizer:
+        @staticmethod
+        def __call__(*_args, **_kwargs):
+            input_ids = torch.tensor([[10], [11]])
+            return {
+                "input_ids": input_ids,
+                "attention_mask": torch.ones_like(input_ids),
+            }
+
+    class ShortJudgeEngine:
+        @staticmethod
+        def generate_answers(*_args, **_kwargs):
+            return ["only one"], ["stop"]
+
+    evaluator.judge_tokenizer = cast("PreTrainedTokenizerBase", TwoPromptTokenizer())
+
+    with pytest.raises(
+        ValueError,
+        match=r"judge-model generation.*prompts=2.*answers=1.*finish_reasons=1",
+    ):
+        evaluator._process_judge_prompts_batch(
+            cast("EvalEngine", ShortJudgeEngine()), ["one", "two"]
+        )
+
+
 def test_get_model_slug_includes_lora_slug(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -560,7 +560,10 @@ def test_load_aligned_generation_dicts_rejects_non_list_fields(
     optional_fields: tuple[str, ...],
 ) -> None:
     evaluator = ConcreteEvaluator.__new__(ConcreteEvaluator)
-    generation = {"prompts": ["prompt"], "answers": ["answer"]}
+    generation: dict[str, object] = {
+        "prompts": ["prompt"],
+        "answers": ["answer"],
+    }
     generation[invalid_field] = invalid_value
     reset_filenames: list[str] = []
     saved: list[tuple[list[dict], str]] = []

--- a/tests/test_free_text_injection_evaluator.py
+++ b/tests/test_free_text_injection_evaluator.py
@@ -3,13 +3,26 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
 
+from llm_behavior_eval.evaluation_utils.free_text_bias_evaluator import (
+    FreeTextBiasEvaluator,
+    _BiasGenerationRecord,
+)
+from llm_behavior_eval.evaluation_utils.free_text_hallu_evaluator import (
+    FreeTextHaluEvaluator,
+    _HalluGenerationRecord,
+)
 from llm_behavior_eval.evaluation_utils.free_text_injection_evaluator import (
     FreeTextPromptInjectionEvaluator,
     _InjectionGenerationRecord,
 )
+from llm_behavior_eval.evaluation_utils.free_text_refusal_evaluator import (
+    FreeTextRefusalEvaluator,
+    _RefusalGenerationRecord,
+)
 
 
 def test_generation_record_rejects_short_generated_answers() -> None:
+    evaluator = object.__new__(FreeTextPromptInjectionEvaluator)
     generation = _InjectionGenerationRecord(
         input_texts=["prompt one", "prompt two"],
         judge_questions=["question one", "question two"],
@@ -25,12 +38,11 @@ def test_generation_record_rejects_short_generated_answers() -> None:
             r".*answers=1.*finish_reasons=1"
         ),
     ):
-        FreeTextPromptInjectionEvaluator._validate_generation_record(
-            generation, context="fresh batch 3"
-        )
+        evaluator._validate_generation_record(generation, context="fresh batch 3")
 
 
 def test_generation_record_rejects_short_finish_reasons() -> None:
+    evaluator = object.__new__(FreeTextPromptInjectionEvaluator)
     generation = _InjectionGenerationRecord(
         input_texts=["prompt"],
         judge_questions=["question"],
@@ -40,12 +52,11 @@ def test_generation_record_rejects_short_finish_reasons() -> None:
     )
 
     with pytest.raises(ValueError, match=r"grading.*finish_reasons=0"):
-        FreeTextPromptInjectionEvaluator._validate_generation_record(
-            generation, context="grading"
-        )
+        evaluator._validate_generation_record(generation, context="grading")
 
 
 def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
+    evaluator = object.__new__(FreeTextPromptInjectionEvaluator)
     generation = FreeTextPromptInjectionEvaluator._generation_from_dict(
         {
             "input_texts": ["legacy question"],
@@ -55,7 +66,98 @@ def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
         }
     )
 
-    FreeTextPromptInjectionEvaluator._validate_generation_record(
-        generation, context="cached batch 0"
-    )
+    evaluator._validate_generation_record(generation, context="cached batch 0")
     assert generation.judge_questions == ["legacy question"]
+
+
+def test_incomplete_cached_generation_keeps_only_valid_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluator = object.__new__(FreeTextPromptInjectionEvaluator)
+    valid = {
+        "input_texts": ["prompt one"],
+        "judge_questions": ["question one"],
+        "gt_answers": ["No"],
+        "answers": ["answer one"],
+        "finish_reasons": ["stop"],
+    }
+    incomplete = {
+        "input_texts": ["prompt two", "prompt three"],
+        "judge_questions": ["question two", "question three"],
+        "gt_answers": ["No", "No"],
+        "answers": ["answer two"],
+        "finish_reasons": ["stop"],
+    }
+    reset_filenames: list[str] = []
+    saved: list[tuple[list[dict], str]] = []
+    monkeypatch.setattr(
+        evaluator,
+        "load_completed_generation_dicts",
+        lambda _filename: [valid, incomplete],
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "reset_generations_file",
+        lambda filename: reset_filenames.append(filename),
+    )
+    monkeypatch.setattr(
+        evaluator,
+        "save_generations",
+        lambda items, filename: saved.append((items, filename)),
+    )
+
+    result = evaluator.load_aligned_generation_dicts(
+        ("input_texts", "gt_answers", "answers", "finish_reasons"),
+        optional_fields=("judge_questions",),
+    )
+
+    assert result == [valid]
+    assert reset_filenames == ["generations.jsonl"]
+    assert saved == [([valid], "generations.jsonl")]
+
+
+@pytest.mark.parametrize(
+    ("evaluator_type", "generation", "short_field"),
+    [
+        (
+            FreeTextHaluEvaluator,
+            _HalluGenerationRecord(
+                input_texts=["one", "two"],
+                gt_answers=["A", "B"],
+                answers=["answer"],
+                finish_reasons=["stop"],
+            ),
+            "answers=1",
+        ),
+        (
+            FreeTextRefusalEvaluator,
+            _RefusalGenerationRecord(
+                input_texts=["one", "two"],
+                expected_labels=["safe", "unsafe"],
+                answers=["answer"],
+                finish_reasons=["stop"],
+            ),
+            "answers=1",
+        ),
+        (
+            FreeTextBiasEvaluator,
+            _BiasGenerationRecord(
+                questions=["one", "two"],
+                correct_answers=["A", "B"],
+                stereotyped_answers=["B", "A"],
+                answers=["answer"],
+                finish_reasons=["stop"],
+            ),
+            "answers=1",
+        ),
+    ],
+)
+def test_all_free_text_evaluators_reject_misaligned_generation_records(
+    evaluator_type: type,
+    generation: object,
+    short_field: str,
+) -> None:
+    evaluator = object.__new__(evaluator_type)
+
+    with pytest.raises(ValueError, match=short_field):
+        evaluator._validate_generation_record(generation, context="grading")

--- a/tests/test_free_text_injection_evaluator.py
+++ b/tests/test_free_text_injection_evaluator.py
@@ -33,12 +33,9 @@ def test_generation_record_rejects_short_generated_answers() -> None:
 
     with pytest.raises(
         ValueError,
-        match=(
-            r"fresh batch 3.*input_texts=2.*judge_questions=2.*gt_answers=2"
-            r".*answers=1.*finish_reasons=1"
-        ),
+        match=r"fresh batch 3.*answers=1",
     ):
-        evaluator._validate_generation_record(generation, context="fresh batch 3")
+        evaluator.validate_generation_record(generation, context="fresh batch 3")
 
 
 def test_generation_record_rejects_short_finish_reasons() -> None:
@@ -52,7 +49,7 @@ def test_generation_record_rejects_short_finish_reasons() -> None:
     )
 
     with pytest.raises(ValueError, match=r"grading.*finish_reasons=0"):
-        evaluator._validate_generation_record(generation, context="grading")
+        evaluator.validate_generation_record(generation, context="grading")
 
 
 def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
@@ -66,7 +63,7 @@ def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
         }
     )
 
-    evaluator._validate_generation_record(generation, context="cached batch 0")
+    evaluator.validate_generation_record(generation, context="cached batch 0")
     assert generation.judge_questions == ["legacy question"]
 
 
@@ -160,4 +157,4 @@ def test_all_free_text_evaluators_reject_misaligned_generation_records(
     evaluator = object.__new__(evaluator_type)
 
     with pytest.raises(ValueError, match=short_field):
-        evaluator._validate_generation_record(generation, context="grading")
+        evaluator.validate_generation_record(generation, context="grading")

--- a/tests/test_free_text_injection_evaluator.py
+++ b/tests/test_free_text_injection_evaluator.py
@@ -1,0 +1,61 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from llm_behavior_eval.evaluation_utils.free_text_injection_evaluator import (
+    FreeTextPromptInjectionEvaluator,
+    _InjectionGenerationRecord,
+)
+
+
+def test_generation_record_rejects_short_generated_answers() -> None:
+    generation = _InjectionGenerationRecord(
+        input_texts=["prompt one", "prompt two"],
+        judge_questions=["question one", "question two"],
+        gt_answers=["No", "No"],
+        answers=["answer one"],
+        finish_reasons=["stop"],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"fresh batch 3.*input_texts=2.*judge_questions=2.*gt_answers=2"
+            r".*answers=1.*finish_reasons=1"
+        ),
+    ):
+        FreeTextPromptInjectionEvaluator._validate_generation_record(
+            generation, context="fresh batch 3"
+        )
+
+
+def test_generation_record_rejects_short_finish_reasons() -> None:
+    generation = _InjectionGenerationRecord(
+        input_texts=["prompt"],
+        judge_questions=["question"],
+        gt_answers=["No"],
+        answers=["answer"],
+        finish_reasons=[],
+    )
+
+    with pytest.raises(ValueError, match=r"grading.*finish_reasons=0"):
+        FreeTextPromptInjectionEvaluator._validate_generation_record(
+            generation, context="grading"
+        )
+
+
+def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
+    generation = FreeTextPromptInjectionEvaluator._generation_from_dict(
+        {
+            "input_texts": ["legacy question"],
+            "gt_answers": ["No"],
+            "answers": ["answer"],
+            "finish_reasons": ["stop"],
+        }
+    )
+
+    FreeTextPromptInjectionEvaluator._validate_generation_record(
+        generation, context="cached batch 0"
+    )
+    assert generation.judge_questions == ["legacy question"]

--- a/tests/test_free_text_injection_evaluator.py
+++ b/tests/test_free_text_injection_evaluator.py
@@ -35,7 +35,7 @@ def test_generation_record_rejects_short_generated_answers() -> None:
         ValueError,
         match=r"fresh batch 3.*answers=1",
     ):
-        evaluator.validate_generation_record(generation, context="fresh batch 3")
+        evaluator._validate_generation_record(generation, context="fresh batch 3")
 
 
 def test_generation_record_rejects_short_finish_reasons() -> None:
@@ -49,7 +49,7 @@ def test_generation_record_rejects_short_finish_reasons() -> None:
     )
 
     with pytest.raises(ValueError, match=r"grading.*finish_reasons=0"):
-        evaluator.validate_generation_record(generation, context="grading")
+        evaluator._validate_generation_record(generation, context="grading")
 
 
 def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
@@ -63,7 +63,7 @@ def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
         }
     )
 
-    evaluator.validate_generation_record(generation, context="cached batch 0")
+    evaluator._validate_generation_record(generation, context="cached batch 0")
     assert generation.judge_questions == ["legacy question"]
 
 
@@ -157,4 +157,4 @@ def test_all_free_text_evaluators_reject_misaligned_generation_records(
     evaluator = object.__new__(evaluator_type)
 
     with pytest.raises(ValueError, match=short_field):
-        evaluator.validate_generation_record(generation, context="grading")
+        evaluator._validate_generation_record(generation, context="grading")

--- a/tests/test_free_text_injection_evaluator.py
+++ b/tests/test_free_text_injection_evaluator.py
@@ -67,52 +67,6 @@ def test_legacy_cached_generation_uses_input_texts_as_judge_questions() -> None:
     assert generation.judge_questions == ["legacy question"]
 
 
-def test_incomplete_cached_generation_keeps_only_valid_prefix(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    evaluator = object.__new__(FreeTextPromptInjectionEvaluator)
-    valid = {
-        "input_texts": ["prompt one"],
-        "judge_questions": ["question one"],
-        "gt_answers": ["No"],
-        "answers": ["answer one"],
-        "finish_reasons": ["stop"],
-    }
-    incomplete = {
-        "input_texts": ["prompt two", "prompt three"],
-        "judge_questions": ["question two", "question three"],
-        "gt_answers": ["No", "No"],
-        "answers": ["answer two"],
-        "finish_reasons": ["stop"],
-    }
-    reset_filenames: list[str] = []
-    saved: list[tuple[list[dict], str]] = []
-    monkeypatch.setattr(
-        evaluator,
-        "load_completed_generation_dicts",
-        lambda _filename: [valid, incomplete],
-    )
-    monkeypatch.setattr(
-        evaluator,
-        "reset_generations_file",
-        lambda filename: reset_filenames.append(filename),
-    )
-    monkeypatch.setattr(
-        evaluator,
-        "save_generations",
-        lambda items, filename: saved.append((items, filename)),
-    )
-
-    result = evaluator.load_aligned_generation_dicts(
-        ("input_texts", "gt_answers", "answers", "finish_reasons"),
-        optional_fields=("judge_questions",),
-    )
-
-    assert result == [valid]
-    assert reset_filenames == ["generations.jsonl"]
-    assert saved == [([valid], "generations.jsonl")]
-
-
 @pytest.mark.parametrize(
     ("evaluator_type", "generation", "short_field"),
     [


### PR DESCRIPTION
# User description
Addresses LLM-119.

## Root cause

The prompt-injection crash exposed a shared invariant gap: target and judge generation, cache resume, and all free-text graders assumed prompts, answers, finish reasons, and evaluator-specific metadata stayed length-aligned.

## What changed

- validate target-model and judge-model answer counts against prompt and finish-reason counts
- centralize cached-generation validation and reuse only the longest valid prefix
- regenerate the first incomplete cached batch and all subsequent batches
- validate full records before persistence and grading in hallucination, prompt injection, refusal, and bias evaluators
- preserve strict zips and legacy prompt-injection caches without `judge_questions`
- add regressions for both engine boundaries, cache recovery, and every affected free-text evaluator

## Impact

Malformed backend or cached output now fails at the invariant boundary with field counts and context instead of surfacing later as an ambiguous `zip()` or indexing error. Valid generation and grading behavior is unchanged.

## Validation

- `ruff format .`
- `ruff check .`
- `pytest -q` — 189 passed

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Validate generation alignment across BaseEvaluator and the free-text evaluators so answer, finish reason, and metadata counts stay locked to prompt counts before persistence or grading. Preserve legacy prompt-injection caches while regenerating incomplete batches, surfacing explicit invariant errors with field counts and context when backend or cached output is malformed.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/149?tool=ast&topic=Validation+flow>Validation flow</a>
        </td><td>Verify generation alignment when BaseEvaluator produces answers and when free-text evaluators grade or cache results, so short judge/target outputs or misaligned metadata are rejected immediately before saving.<details><summary>Modified files (7)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py</li>
<li>tests/test_base_evaluator.py</li>
<li>tests/test_free_text_injection_evaluator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Mark generation valida...</td><td>July 15, 2026</td></tr>
<tr><td>Ilagri</td><td>Add Bloom gender and r...</td><td>June 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/149?tool=ast&topic=Cache+handling>Cache handling</a>
        </td><td>Regenerate incomplete cached batches by reusing the longest valid prefix, validating optional fields, and falling back to legacy prompt-injection metadata so strict alignment survives cache recovery.<details><summary>Modified files (5)</summary><ul><li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_bias_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_hallu_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_injection_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Mark generation valida...</td><td>July 15, 2026</td></tr>
<tr><td>Ilagri</td><td>Add Bloom gender and r...</td><td>June 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/149?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>