### PR TITLE
LLM-120: Separate dataset identity from loading source

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,3 +3,26 @@ llm-behavior-eval Documentation
 
 .. automodule:: llm_behavior_eval
     :members:
+
+Local and offline datasets
+--------------------------
+
+``DatasetConfig.file_path`` is the physical loading source and may be a local
+directory. Set ``DatasetConfig.dataset_id`` to the canonical dataset identifier
+so evaluator dispatch, prompts, output names, metrics, and provenance match the
+online preset. If omitted, ``dataset_id`` defaults to ``file_path``.
+
+.. code-block:: python
+
+    DatasetConfig(
+        file_path="/opt/assets/halueval",
+        dataset_id="hirundo-io/halueval",
+        dataset_type=DatasetType.BIAS,
+    )
+
+Release tooling can call ``list_dataset_presets()`` to enumerate every supported
+preset and its complete ``dataset_ids`` expansion. ``expand_dataset_preset()``
+provides the same expansion used by the CLI.
+
+.. automodule:: llm_behavior_eval.presets
+    :members:

--- a/llm_behavior_eval/__init__.py
+++ b/llm_behavior_eval/__init__.py
@@ -13,6 +13,7 @@ from .evaluation_utils.util_functions import (
     safe_apply_chat_template,
 )
 from .evaluation_utils.vllm_config import VllmConfig
+from .presets import DatasetPreset, expand_dataset_preset, list_dataset_presets
 
 __all__ = [
     "EvaluateFactory",
@@ -30,6 +31,9 @@ __all__ = [
     "load_tokenizer_with_transformers",
     "pick_best_dtype",
     "safe_apply_chat_template",
+    "DatasetPreset",
+    "expand_dataset_preset",
+    "list_dataset_presets",
 ]
 
 __version__ = "0.1.6b11"

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -32,16 +32,13 @@ from llm_behavior_eval.evaluation_utils.eval_config import (
     EvaluatorFamily,
 )
 from llm_behavior_eval.evaluation_utils.evaluate_factory import EvaluateFactory
-from llm_behavior_eval.evaluation_utils.refusal_utils import (
-    OR_BENCH_DATASET,
-    XSTEST_DATASET,
-)
 from llm_behavior_eval.evaluation_utils.sampling_config import SamplingConfig
 from llm_behavior_eval.evaluation_utils.util_functions import (
     empty_cuda_cache_if_available,
 )
 from llm_behavior_eval.evaluation_utils.vllm_config import VllmConfig
 from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
+from llm_behavior_eval.presets import expand_dataset_preset
 
 torch.set_float32_matmul_precision("high")
 
@@ -118,20 +115,16 @@ def _behavior_presets(behavior: str) -> list[str]:
 
     # Hallucination shortcuts
     if behavior in HALUEVAL_ALIAS:
-        return ["hirundo-io/halueval"]
+        return expand_dataset_preset("hallu")
     if behavior in MEDHALLU_ALIAS:
-        return ["hirundo-io/medhallu"]
+        return expand_dataset_preset("hallu-med")
     if behavior in INJECTION_ALIAS:
-        return ["hirundo-io/prompt-injection-purple-llama"]
+        return expand_dataset_preset("prompt-injection")
     if len(behavior_parts) == 2 and behavior_parts[0] in REFUSAL_ALIAS:
         _, refusal_dataset = behavior_parts
-        if refusal_dataset == "xstest":
-            return [XSTEST_DATASET]
-        if refusal_dataset == "orbench":
-            return [OR_BENCH_DATASET]
-        if refusal_dataset == "all":
-            return [XSTEST_DATASET, OR_BENCH_DATASET]
-        raise ValueError("Refusal supports: xstest, orbench, all")
+        if refusal_dataset not in {"xstest", "orbench", "all"}:
+            raise ValueError("Refusal supports: xstest, orbench, all")
+        return expand_dataset_preset(f"refusal:{refusal_dataset}")
 
     # Expected structures:
     # [kind, bias_type] for BBQ, where kind in {bias, unbias}
@@ -144,7 +137,7 @@ def _behavior_presets(behavior: str) -> list[str]:
     if len(behavior_parts) == 2:
         kind, bias_type = behavior_parts
         allowed_types, allowed_kinds, kind_error, support_label = BBQ_BIAS_BEHAVIOR
-        return _resolve_bias_behavior(
+        _resolve_bias_behavior(
             "bbq",
             kind,
             bias_type,
@@ -153,6 +146,7 @@ def _behavior_presets(behavior: str) -> list[str]:
             kind_error,
             support_label,
         )
+        return expand_dataset_preset(f"{kind}:{bias_type}")
 
     if len(behavior_parts) == 3:
         prefix, kind, bias_type = behavior_parts
@@ -162,7 +156,7 @@ def _behavior_presets(behavior: str) -> list[str]:
         allowed_types, allowed_kinds, kind_error, support_label = (
             THREE_PART_BIAS_BEHAVIORS[prefix]
         )
-        return _resolve_bias_behavior(
+        _resolve_bias_behavior(
             prefix,
             kind,
             bias_type,
@@ -171,6 +165,7 @@ def _behavior_presets(behavior: str) -> list[str]:
             kind_error,
             support_label,
         )
+        return expand_dataset_preset(f"{prefix}:{kind}:{bias_type}")
 
     if len(behavior_parts) == 4:
         prefix, kind, bias_type, context = behavior_parts
@@ -180,7 +175,7 @@ def _behavior_presets(behavior: str) -> list[str]:
             and context == "ambiguous"
             and bias_type in BLOOM_BIAS_TYPES
         ):
-            return [f"hirundo-io/bloom-{bias_type}-ambiguous-bias-free-text"]
+            return expand_dataset_preset(f"bloom:bias:{bias_type}:ambiguous")
         raise ValueError("Use 'bloom:bias:<type>:ambiguous'")
 
     raise ValueError(BEHAVIOR_PRESET_ERROR)

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -38,7 +38,7 @@ from llm_behavior_eval.evaluation_utils.util_functions import (
 )
 from llm_behavior_eval.evaluation_utils.vllm_config import VllmConfig
 from llm_behavior_eval.evaluation_utils.vllm_types import TokenizerModeOption
-from llm_behavior_eval.presets import expand_dataset_preset
+from llm_behavior_eval.presets import build_bias_dataset_id, expand_dataset_preset
 
 torch.set_float32_matmul_precision("high")
 
@@ -70,13 +70,11 @@ def _resolve_bias_behavior(
 
     allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
     if bias_type == "all":
-        return [
-            f"hirundo-io/{prefix}-{bt}-{kind}-free-text" for bt in sorted(allowed_types)
-        ]
+        return [build_bias_dataset_id(prefix, bt, kind) for bt in sorted(allowed_types)]
 
     if bias_type not in allowed_types:
         raise ValueError(f"{support_label} supports: {allowed_with_all}")
-    return [f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"]
+    return [build_bias_dataset_id(prefix, bias_type, kind)]
 
 
 def _default_results_dir() -> Path:

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -70,7 +70,10 @@ def _resolve_bias_behavior(
 
     allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
     if bias_type == "all":
-        return [build_bias_dataset_id(prefix, bt, kind) for bt in sorted(allowed_types)]
+        return [
+            build_bias_dataset_id(prefix, bias_type, kind)
+            for bias_type in sorted(allowed_types)
+        ]
 
     if bias_type not in allowed_types:
         raise ValueError(f"{support_label} supports: {allowed_with_all}")

--- a/llm_behavior_eval/evaluate.py
+++ b/llm_behavior_eval/evaluate.py
@@ -71,8 +71,8 @@ def _resolve_bias_behavior(
     allowed_with_all = ", ".join(sorted(list(allowed_types)) + ["all"])
     if bias_type == "all":
         return [
-            build_bias_dataset_id(prefix, bias_type, kind)
-            for bias_type in sorted(allowed_types)
+            build_bias_dataset_id(prefix, allowed_bias_type, kind)
+            for allowed_bias_type in sorted(allowed_types)
         ]
 
     if bias_type not in allowed_types:

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -238,8 +238,7 @@ class BaseEvaluator(ABC):
         Returns:
             The slug for the dataset.
         """
-        dataset_id = cast("str", self.dataset_config.dataset_id)
-        return dataset_id.split("/")[-1]
+        return self.dataset_config.dataset_id.split("/")[-1]
 
     def get_output_dir(self) -> Path:
         """
@@ -274,7 +273,7 @@ class BaseEvaluator(ABC):
             trust_remote_code=self.trust_remote_code,
             token=self.eval_config.model_token,
         )
-        custom_dataset.dataset_id = cast("str", self.dataset_config.dataset_id)
+        custom_dataset.dataset_id = self.dataset_config.dataset_id
         test_dataset = custom_dataset.preprocess(
             self.tokenizer,
             self.dataset_config.preprocess_config,
@@ -805,7 +804,7 @@ class BaseEvaluator(ABC):
                     "Main MLFlow run not found, cannot launch dataset run before initializing MLFlow"
                 )
             if self.mlflow_config.mlflow_run_id:
-                logging.info(
+                logging.warning(
                     "Attaching dataset to existing run %s (dataset_id=%s, dataset_type=%s)",
                     self.mlflow_config.mlflow_run_id,
                     self.dataset_config.dataset_id,
@@ -990,6 +989,12 @@ class BaseEvaluator(ABC):
 
         with open(config_path) as file_handle:
             existing_run_config = json.load(file_handle)
+
+        existing_dataset_config = existing_run_config.get("dataset_config", {})
+        if "dataset_id" not in existing_dataset_config:
+            existing_dataset_config["dataset_id"] = existing_dataset_config.get(
+                "file_path"
+            )
 
         if existing_run_config == run_config:
             logging.info(

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -238,7 +238,8 @@ class BaseEvaluator(ABC):
         Returns:
             The slug for the dataset.
         """
-        return self.dataset_config.file_path.split("/")[-1]
+        dataset_id = cast("str", self.dataset_config.dataset_id)
+        return dataset_id.split("/")[-1]
 
     def get_output_dir(self) -> Path:
         """
@@ -273,6 +274,7 @@ class BaseEvaluator(ABC):
             trust_remote_code=self.trust_remote_code,
             token=self.eval_config.model_token,
         )
+        custom_dataset.dataset_id = cast("str", self.dataset_config.dataset_id)
         test_dataset = custom_dataset.preprocess(
             self.tokenizer,
             self.dataset_config.preprocess_config,
@@ -804,9 +806,9 @@ class BaseEvaluator(ABC):
                 )
             if self.mlflow_config.mlflow_run_id:
                 logging.info(
-                    "Attaching dataset to existing run %s (file_path=%s, dataset_type=%s)",
+                    "Attaching dataset to existing run %s (dataset_id=%s, dataset_type=%s)",
                     self.mlflow_config.mlflow_run_id,
-                    self.dataset_config.file_path,
+                    self.dataset_config.dataset_id,
                     self.dataset_config.dataset_type,
                 )
             self._mlflow_datasets_attached += 1

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -804,7 +804,7 @@ class BaseEvaluator(ABC):
                     "Main MLFlow run not found, cannot launch dataset run before initializing MLFlow"
                 )
             if self.mlflow_config.mlflow_run_id:
-                logging.warning(
+                logging.info(
                     "Attaching dataset to existing run %s (dataset_id=%s, dataset_type=%s)",
                     self.mlflow_config.mlflow_run_id,
                     self.dataset_config.dataset_id,
@@ -991,6 +991,7 @@ class BaseEvaluator(ABC):
             existing_run_config = json.load(file_handle)
 
         existing_dataset_config = existing_run_config.get("dataset_config", {})
+        # Pre-dataset_id run configs used file_path as both source and identity.
         if "dataset_id" not in existing_dataset_config:
             existing_dataset_config["dataset_id"] = existing_dataset_config.get(
                 "file_path"

--- a/llm_behavior_eval/evaluation_utils/base_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/base_evaluator.py
@@ -272,8 +272,8 @@ class BaseEvaluator(ABC):
             self.dataset_config.dataset_type,
             trust_remote_code=self.trust_remote_code,
             token=self.eval_config.model_token,
+            dataset_id=self.dataset_config.dataset_id,
         )
-        custom_dataset.dataset_id = self.dataset_config.dataset_id
         test_dataset = custom_dataset.preprocess(
             self.tokenizer,
             self.dataset_config.preprocess_config,

--- a/llm_behavior_eval/evaluation_utils/custom_dataset.py
+++ b/llm_behavior_eval/evaluation_utils/custom_dataset.py
@@ -170,6 +170,7 @@ class CustomDataset:
         self,
         file_path: Path | str,
         dataset_type: DatasetType,
+        dataset_id: str | None = None,
         trust_remote_code: bool = False,
         token: str | None = None,
     ):
@@ -179,10 +180,12 @@ class CustomDataset:
         Args:
             file_path: Local path or HuggingFace dataset identifier.
             dataset_type: The type of the dataset (e.g., BIAS or UNBIAS).
+            dataset_id: Logical dataset identity. Defaults to ``file_path``.
             trust_remote_code: Whether to trust remote code when loading the dataset.
             token: HuggingFace token for gated or private dataset repos.
         """
         self.file_path = file_path
+        self.dataset_id = dataset_id or str(file_path)
         self.dataset_type = dataset_type
         self.trust_remote_code = trust_remote_code
         self.token = token
@@ -236,7 +239,7 @@ class CustomDataset:
         Returns:
             A tokenized dataset ready for evaluation.
         """
-        refusal_dataset = str(self.file_path) in REFUSAL_DATASETS
+        refusal_dataset = self.dataset_id in REFUSAL_DATASETS
         dataset = normalize_refusal_dataset(self.ds) if refusal_dataset else self.ds
         validate_dataset_columns(dataset)
         old_columns = dataset.column_names

--- a/llm_behavior_eval/evaluation_utils/custom_dataset.py
+++ b/llm_behavior_eval/evaluation_utils/custom_dataset.py
@@ -170,9 +170,9 @@ class CustomDataset:
         self,
         file_path: Path | str,
         dataset_type: DatasetType,
-        dataset_id: str | None = None,
         trust_remote_code: bool = False,
         token: str | None = None,
+        dataset_id: str | None = None,
     ):
         """
         Initializes the custom dataset with a specified dataset type and behavior type.
@@ -180,9 +180,9 @@ class CustomDataset:
         Args:
             file_path: Local path or HuggingFace dataset identifier.
             dataset_type: The type of the dataset (e.g., BIAS or UNBIAS).
-            dataset_id: Logical dataset identity. Defaults to ``file_path``.
             trust_remote_code: Whether to trust remote code when loading the dataset.
             token: HuggingFace token for gated or private dataset repos.
+            dataset_id (optional): Logical dataset identity. Defaults to ``file_path``.
         """
         self.file_path = file_path
         self.dataset_id = dataset_id or str(file_path)

--- a/llm_behavior_eval/evaluation_utils/dataset_config.py
+++ b/llm_behavior_eval/evaluation_utils/dataset_config.py
@@ -49,5 +49,5 @@ class DatasetConfig(BaseSettings):
     def default_dataset_id(cls, value: object, info: ValidationInfo) -> object:
         """Use the loading source as the logical identity for legacy callers."""
         if value is None or value == "":
-            return info.data["file_path"]
+            return info.data.get("file_path", value)
         return value

--- a/llm_behavior_eval/evaluation_utils/dataset_config.py
+++ b/llm_behavior_eval/evaluation_utils/dataset_config.py
@@ -1,3 +1,4 @@
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .enums import DatasetType
@@ -25,7 +26,9 @@ class DatasetConfig(BaseSettings):
     DatasetConfig is a configuration class for defining the settings of a dataset.
 
     Attributes:
-        file_path: The HuggingFace repo id of the dataset file.
+        file_path: Local path or Hugging Face repository used to load the dataset.
+        dataset_id: Stable logical identity used for evaluator selection and results.
+            Defaults to ``file_path`` for backward compatibility.
         dataset_type: The type of the dataset, represented as an enum.
         preprocess_config: Configuration for preprocessing the dataset.
         seed: The random seed for reproducibility.
@@ -34,6 +37,14 @@ class DatasetConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="bias_dataset_")
 
     file_path: str
+    dataset_id: str | None = None
     dataset_type: DatasetType
     preprocess_config: PreprocessConfig = PreprocessConfig()
     seed: int | None = 42
+
+    @model_validator(mode="after")
+    def default_dataset_id(self) -> "DatasetConfig":
+        """Use the loading source as the logical identity for legacy callers."""
+        if self.dataset_id is None:
+            self.dataset_id = self.file_path
+        return self

--- a/llm_behavior_eval/evaluation_utils/dataset_config.py
+++ b/llm_behavior_eval/evaluation_utils/dataset_config.py
@@ -1,4 +1,4 @@
-from pydantic import model_validator
+from pydantic import ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .enums import DatasetType
@@ -34,17 +34,18 @@ class DatasetConfig(BaseSettings):
         seed: The random seed for reproducibility.
     """
 
-    model_config = SettingsConfigDict(env_prefix="bias_dataset_")
+    model_config = SettingsConfigDict(
+        env_prefix="bias_dataset_", validate_assignment=True, validate_default=True
+    )
 
     file_path: str
-    dataset_id: str | None = None
+    dataset_id: str = ""
     dataset_type: DatasetType
     preprocess_config: PreprocessConfig = PreprocessConfig()
     seed: int | None = 42
 
-    @model_validator(mode="after")
-    def default_dataset_id(self) -> "DatasetConfig":
+    @field_validator("dataset_id", mode="before")
+    @classmethod
+    def default_dataset_id(cls, value: object, info: ValidationInfo) -> object:
         """Use the loading source as the logical identity for legacy callers."""
-        if self.dataset_id is None:
-            self.dataset_id = self.file_path
-        return self
+        return value or info.data["file_path"]

--- a/llm_behavior_eval/evaluation_utils/dataset_config.py
+++ b/llm_behavior_eval/evaluation_utils/dataset_config.py
@@ -48,4 +48,6 @@ class DatasetConfig(BaseSettings):
     @classmethod
     def default_dataset_id(cls, value: object, info: ValidationInfo) -> object:
         """Use the loading source as the logical identity for legacy callers."""
-        return value or info.data["file_path"]
+        if value is None or value == "":
+            return info.data["file_path"]
+        return value

--- a/llm_behavior_eval/evaluation_utils/evaluate_factory.py
+++ b/llm_behavior_eval/evaluation_utils/evaluate_factory.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from .base_evaluator import BaseEvaluator
 from .dataset_config import DatasetConfig
 from .eval_config import EvaluationConfig, EvaluatorFamily
@@ -37,7 +35,7 @@ class EvaluateFactory:
         Returns:
             An instance of a class that inherits from BaseEvaluator.
         """
-        dataset_id = cast("str", dataset_config.dataset_id)
+        dataset_id = dataset_config.dataset_id
         evaluator_family = EvaluateFactory.get_evaluator_family(dataset_id)
         resolved_eval_config = eval_config.resolve_for_family(evaluator_family)
         if evaluator_family == "hallucination":

--- a/llm_behavior_eval/evaluation_utils/evaluate_factory.py
+++ b/llm_behavior_eval/evaluation_utils/evaluate_factory.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from .base_evaluator import BaseEvaluator
 from .dataset_config import DatasetConfig
 from .eval_config import EvaluationConfig, EvaluatorFamily
@@ -35,7 +37,7 @@ class EvaluateFactory:
         Returns:
             An instance of a class that inherits from BaseEvaluator.
         """
-        dataset_id = dataset_config.file_path
+        dataset_id = cast("str", dataset_config.dataset_id)
         evaluator_family = EvaluateFactory.get_evaluator_family(dataset_id)
         resolved_eval_config = eval_config.resolve_for_family(evaluator_family)
         if evaluator_family == "hallucination":

--- a/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
+++ b/llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py
@@ -195,12 +195,12 @@ class FreeTextRefusalEvaluator(FreeTextSharedEvaluator):
         return generations
 
     def _judge_prompt_template(self) -> str:
-        if self.dataset_config.file_path == OR_BENCH_DATASET:
+        if self.dataset_config.dataset_id == OR_BENCH_DATASET:
             return OR_BENCH_JUDGE_PROMPT
         return XSTEST_JUDGE_PROMPT
 
     def _parse_judge_text(self, text: str) -> RefusalJudgment:
-        if self.dataset_config.file_path == OR_BENCH_DATASET:
+        if self.dataset_config.dataset_id == OR_BENCH_DATASET:
             return parse_or_bench_judgment(text)
         return parse_xstest_judgment(text)
 

--- a/llm_behavior_eval/presets.py
+++ b/llm_behavior_eval/presets.py
@@ -18,13 +18,27 @@ class DatasetPreset:
     dataset_ids: tuple[str, ...]
 
 
+def build_bias_dataset_id(prefix: str, bias_type: str, kind: str) -> str:
+    """Build the canonical identifier for a bias dataset asset.
+
+    Args:
+        prefix: Dataset family, such as ``bbq`` or ``bloom``.
+        bias_type: Bias category, such as ``age`` or ``gender``.
+        kind: Dataset variant, such as ``bias`` or ``unbias``.
+
+    Returns:
+        str: Canonical Hugging Face dataset identifier.
+    """
+    return f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"
+
+
 def _bias_ids(
     prefix: str, kinds: set[str], bias_types: set[str]
 ) -> list[DatasetPreset]:
     presets: list[DatasetPreset] = []
     for kind in sorted(kinds):
         ids = tuple(
-            f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"
+            build_bias_dataset_id(prefix, bias_type, kind)
             for bias_type in sorted(bias_types)
         )
         presets.extend(

--- a/llm_behavior_eval/presets.py
+++ b/llm_behavior_eval/presets.py
@@ -62,12 +62,28 @@ PRESET_CATALOG = {preset.name: preset for preset in _PRESETS}
 
 
 def list_dataset_presets() -> tuple[DatasetPreset, ...]:
-    """Return every supported preset and its complete asset expansion."""
+    """Return every supported preset and its complete asset expansion.
+
+    Returns:
+        tuple[DatasetPreset, ...]: Every supported preset and its complete asset
+        expansion in deterministic catalog order.
+    """
     return _PRESETS
 
 
 def expand_dataset_preset(name: str) -> list[str]:
-    """Expand a supported CLI preset into canonical dataset identifiers."""
+    """Expand a supported CLI preset into canonical dataset identifiers.
+
+    Args:
+        name: Case-insensitive preset key from ``PRESET_CATALOG``, such as
+            ``bloom:bias:gender:ambiguous`` or ``refusal:all``.
+
+    Returns:
+        list[str]: Canonical dataset identifiers required by the preset.
+
+    Raises:
+        ValueError: If ``name`` is not a supported preset key.
+    """
     try:
         return list(PRESET_CATALOG[name.lower()].dataset_ids)
     except KeyError as exc:

--- a/llm_behavior_eval/presets.py
+++ b/llm_behavior_eval/presets.py
@@ -2,7 +2,12 @@
 
 from dataclasses import dataclass
 
-from .evaluation_utils.enums import BBQ_BIAS_TYPES, BLOOM_BIAS_TYPES, UNQOVER_BIAS_TYPES
+from .evaluation_utils.enums import (
+    BBQ_BIAS_TYPES,
+    BIAS_KINDS,
+    BLOOM_BIAS_TYPES,
+    UNQOVER_BIAS_TYPES,
+)
 from .evaluation_utils.refusal_utils import OR_BENCH_DATASET, XSTEST_DATASET
 
 
@@ -55,15 +60,15 @@ def _bias_ids(
 
 
 _PRESETS = (
-    *_bias_ids("bbq", {"bias", "unbias"}, BBQ_BIAS_TYPES),
+    *_bias_ids("bbq", BIAS_KINDS, BBQ_BIAS_TYPES),
     *_bias_ids("unqover", {"bias"}, UNQOVER_BIAS_TYPES),
-    *_bias_ids("bloom", {"bias", "unbias"}, BLOOM_BIAS_TYPES),
+    *_bias_ids("bloom", BIAS_KINDS, BLOOM_BIAS_TYPES),
     *(
         DatasetPreset(
-            f"bloom:bias:{kind}:ambiguous",
-            (f"hirundo-io/bloom-{kind}-ambiguous-bias-free-text",),
+            f"bloom:bias:{bias_type}:ambiguous",
+            (f"hirundo-io/bloom-{bias_type}-ambiguous-bias-free-text",),
         )
-        for kind in sorted(BLOOM_BIAS_TYPES)
+        for bias_type in sorted(BLOOM_BIAS_TYPES)
     ),
     DatasetPreset("hallu", ("hirundo-io/halueval",)),
     DatasetPreset("hallu-med", ("hirundo-io/medhallu",)),
@@ -72,7 +77,7 @@ _PRESETS = (
     DatasetPreset("refusal:orbench", (OR_BENCH_DATASET,)),
     DatasetPreset("refusal:all", (XSTEST_DATASET, OR_BENCH_DATASET)),
 )
-PRESET_CATALOG = {preset.name: preset for preset in _PRESETS}
+_PRESETS_BY_NAME = {preset.name: preset for preset in _PRESETS}
 
 
 def list_dataset_presets() -> tuple[DatasetPreset, ...]:
@@ -89,7 +94,7 @@ def expand_dataset_preset(name: str) -> list[str]:
     """Expand a supported CLI preset into canonical dataset identifiers.
 
     Args:
-        name: Case-insensitive preset key from ``PRESET_CATALOG``, such as
+        name: Case-insensitive supported preset key, such as
             ``bloom:bias:gender:ambiguous`` or ``refusal:all``.
 
     Returns:
@@ -99,6 +104,6 @@ def expand_dataset_preset(name: str) -> list[str]:
         ValueError: If ``name`` is not a supported preset key.
     """
     try:
-        return list(PRESET_CATALOG[name.lower()].dataset_ids)
+        return list(_PRESETS_BY_NAME[name.lower()].dataset_ids)
     except KeyError as exc:
         raise ValueError(f"Unknown behavior preset: {name}") from exc

--- a/llm_behavior_eval/presets.py
+++ b/llm_behavior_eval/presets.py
@@ -1,0 +1,74 @@
+"""Public catalog of supported behavior-evaluation dataset presets."""
+
+from dataclasses import dataclass
+
+from .evaluation_utils.enums import BBQ_BIAS_TYPES, BLOOM_BIAS_TYPES, UNQOVER_BIAS_TYPES
+from .evaluation_utils.refusal_utils import OR_BENCH_DATASET, XSTEST_DATASET
+
+
+@dataclass(frozen=True)
+class DatasetPreset:
+    """A CLI preset and the canonical dataset assets required to expand it.
+
+    ``dataset_ids`` contains every Hugging Face dataset repository needed for the
+    preset. Future catalog versions may add revisions and checksums.
+    """
+
+    name: str
+    dataset_ids: tuple[str, ...]
+
+
+def _bias_ids(
+    prefix: str, kinds: set[str], bias_types: set[str]
+) -> list[DatasetPreset]:
+    presets: list[DatasetPreset] = []
+    for kind in sorted(kinds):
+        ids = tuple(
+            f"hirundo-io/{prefix}-{bias_type}-{kind}-free-text"
+            for bias_type in sorted(bias_types)
+        )
+        presets.extend(
+            DatasetPreset(
+                f"{prefix + ':' if prefix != 'bbq' else ''}{kind}:{bias_type}",
+                (dataset_id,),
+            )
+            for bias_type, dataset_id in zip(sorted(bias_types), ids, strict=True)
+        )
+        presets.append(
+            DatasetPreset(f"{prefix + ':' if prefix != 'bbq' else ''}{kind}:all", ids)
+        )
+    return presets
+
+
+_PRESETS = (
+    *_bias_ids("bbq", {"bias", "unbias"}, BBQ_BIAS_TYPES),
+    *_bias_ids("unqover", {"bias"}, UNQOVER_BIAS_TYPES),
+    *_bias_ids("bloom", {"bias", "unbias"}, BLOOM_BIAS_TYPES),
+    *(
+        DatasetPreset(
+            f"bloom:bias:{kind}:ambiguous",
+            (f"hirundo-io/bloom-{kind}-ambiguous-bias-free-text",),
+        )
+        for kind in sorted(BLOOM_BIAS_TYPES)
+    ),
+    DatasetPreset("hallu", ("hirundo-io/halueval",)),
+    DatasetPreset("hallu-med", ("hirundo-io/medhallu",)),
+    DatasetPreset("prompt-injection", ("hirundo-io/prompt-injection-purple-llama",)),
+    DatasetPreset("refusal:xstest", (XSTEST_DATASET,)),
+    DatasetPreset("refusal:orbench", (OR_BENCH_DATASET,)),
+    DatasetPreset("refusal:all", (XSTEST_DATASET, OR_BENCH_DATASET)),
+)
+PRESET_CATALOG = {preset.name: preset for preset in _PRESETS}
+
+
+def list_dataset_presets() -> tuple[DatasetPreset, ...]:
+    """Return every supported preset and its complete asset expansion."""
+    return _PRESETS
+
+
+def expand_dataset_preset(name: str) -> list[str]:
+    """Expand a supported CLI preset into canonical dataset identifiers."""
+    try:
+        return list(PRESET_CATALOG[name.lower()].dataset_ids)
+    except KeyError as exc:
+        raise ValueError(f"Unknown behavior preset: {name}") from exc

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -175,11 +175,13 @@ def patch_custom_dataset(
             *,
             trust_remote_code: bool = False,
             token: str | None = None,
+            dataset_id: str | None = None,
         ) -> None:
             capture_state.init_args = (file_path, dataset_type)
             capture_state.trust_remote_code = trust_remote_code
             capture_state.token = token
             self.trust_remote_code = trust_remote_code
+            self.dataset_id = dataset_id or file_path
             self.has_stereotype = False
 
         def preprocess(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -77,6 +77,7 @@ class CaptureState:
     token: str | None = None
     padding_side_at_preprocess: str | None = None
     init_args: tuple[str, DatasetType] | None = None
+    custom_dataset_id: str | None = None
     engine_inits: list[bool] = field(default_factory=list)
     set_dataset_calls: list[tuple[bool, Sized]] = field(default_factory=list)
     free_model_calls: list[bool] = field(default_factory=list)
@@ -180,6 +181,7 @@ def patch_custom_dataset(
             capture_state.init_args = (file_path, dataset_type)
             capture_state.trust_remote_code = trust_remote_code
             capture_state.token = token
+            capture_state.custom_dataset_id = dataset_id
             self.trust_remote_code = trust_remote_code
             self.dataset_id = dataset_id or file_path
             self.has_stereotype = False
@@ -271,6 +273,34 @@ def test_prepare_dataloader_receives_eval_engine_tokenizer(
     assert evaluator.eval_loader == "loader"
     assert evaluator.num_samples == 3
     assert capture_state.engine_dataset == evaluator.eval_dataset
+
+
+def test_prepare_dataloader_propagates_explicit_and_default_dataset_id(
+    tmp_path: Path, capture_state: CaptureState
+) -> None:
+    evaluation_config = EvaluationConfig(
+        model_path_or_repo_id="meta/model",
+        results_dir=tmp_path,
+        max_samples=1,
+    )
+    evaluator = ConcreteEvaluator(
+        evaluation_config,
+        DatasetConfig(
+            file_path="/opt/assets/halueval",
+            dataset_id="hirundo-io/halueval",
+            dataset_type=DatasetType.BIAS,
+        ),
+    )
+
+    assert capture_state.custom_dataset_id == "hirundo-io/halueval"
+
+    evaluator.dataset_config = DatasetConfig(
+        file_path="repo/fallback-dataset",
+        dataset_type=DatasetType.BIAS,
+    )
+    evaluator.prepare_dataloader()
+
+    assert capture_state.custom_dataset_id == "repo/fallback-dataset"
 
 
 def test_mlflow_initializes_after_dataloader_preparation(

--- a/tests/test_base_evaluator.py
+++ b/tests/test_base_evaluator.py
@@ -1340,6 +1340,35 @@ def test_run_config_mismatch_allows_skip_reusing_existing_outputs(
     )
 
 
+def test_legacy_run_config_without_dataset_id_reuses_cached_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    eval_config = EvaluationConfig(
+        model_path_or_repo_id="meta/model",
+        results_dir=tmp_path,
+        max_samples=1,
+    )
+    dataset_config = DatasetConfig(
+        file_path="repo/dataset",
+        dataset_type=DatasetType.BIAS,
+    )
+    evaluator = ConcreteEvaluator(eval_config, dataset_config)
+    run_config_path = evaluator.run_config_path()
+    run_config = json.loads(run_config_path.read_text(encoding="utf-8"))
+    run_config["dataset_config"].pop("dataset_id")
+    run_config_path.write_text(json.dumps(run_config), encoding="utf-8")
+    monkeypatch.setattr(
+        base_evaluator_module.typer,
+        "prompt",
+        lambda *_args, **_kwargs: pytest.fail("matching legacy config prompted"),
+    )
+
+    ConcreteEvaluator(eval_config, dataset_config)
+
+    persisted = json.loads(run_config_path.read_text(encoding="utf-8"))
+    assert "dataset_id" not in persisted["dataset_config"]
+
+
 def test_run_config_mismatch_cancel_still_raises_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -295,7 +295,10 @@ def test_custom_dataset_preprocess_switches_default_system_prompt_by_dataset_fam
         custom_dataset_module, "safe_apply_chat_template", fake_safe_apply_chat_template
     )
 
-    custom_dataset = CustomDataset(dataset_id, DatasetType.BIAS)
+    load_source = (
+        "/opt/assets/or-bench" if dataset_id == OR_BENCH_DATASET else dataset_id
+    )
+    custom_dataset = CustomDataset(load_source, DatasetType.BIAS, dataset_id=dataset_id)
     if dataset_id == OR_BENCH_DATASET:
         monkeypatch.setattr(
             custom_dataset_module,

--- a/tests/test_dataset_identity.py
+++ b/tests/test_dataset_identity.py
@@ -24,6 +24,16 @@ def test_dataset_id_defaults_to_loading_source() -> None:
     assert config.dataset_id == config.file_path
 
 
+def test_dataset_id_assignment_cannot_leave_none() -> None:
+    config = DatasetConfig(
+        file_path="hirundo-io/halueval", dataset_type=DatasetType.BIAS
+    )
+
+    config.dataset_id = None  # type: ignore[assignment]
+
+    assert config.dataset_id == config.file_path
+
+
 def test_local_source_dispatches_by_logical_dataset_id() -> None:
     config = DatasetConfig(
         file_path="/opt/assets/halueval",

--- a/tests/test_dataset_identity.py
+++ b/tests/test_dataset_identity.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from datasets import Dataset, DatasetDict
+
+from llm_behavior_eval import (
+    DatasetConfig,
+    DatasetType,
+    EvaluateFactory,
+    expand_dataset_preset,
+    list_dataset_presets,
+)
+from llm_behavior_eval.evaluation_utils.base_evaluator import BaseEvaluator
+from llm_behavior_eval.evaluation_utils.custom_dataset import CustomDataset
+from llm_behavior_eval.evaluation_utils.refusal_utils import OR_BENCH_DATASET
+
+
+def test_dataset_id_defaults_to_loading_source() -> None:
+    config = DatasetConfig(
+        file_path="hirundo-io/halueval", dataset_type=DatasetType.BIAS
+    )
+
+    assert config.dataset_id == config.file_path
+
+
+def test_local_source_dispatches_by_logical_dataset_id() -> None:
+    config = DatasetConfig(
+        file_path="/opt/assets/halueval",
+        dataset_id="hirundo-io/halueval",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    assert config.dataset_id is not None
+    assert EvaluateFactory.get_evaluator_family(config.dataset_id) == "hallucination"
+
+
+def test_output_and_provenance_retain_logical_identity() -> None:
+    config = DatasetConfig(
+        file_path="/opt/assets/halueval",
+        dataset_id="hirundo-io/halueval",
+        dataset_type=DatasetType.BIAS,
+    )
+    evaluator = SimpleNamespace(dataset_config=config)
+
+    assert BaseEvaluator.get_dataset_slug(evaluator) == "halueval"  # type: ignore[arg-type]
+    assert config.model_dump()["dataset_id"] == "hirundo-io/halueval"
+    assert config.model_dump()["file_path"] == "/opt/assets/halueval"
+
+
+def test_custom_dataset_loads_source_but_normalizes_by_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded: list[str] = []
+
+    def fake_load_dataset(source: str, **_: object) -> DatasetDict:
+        loaded.append(source)
+        return DatasetDict(
+            {"train": Dataset.from_dict({"question": ["q"], "label": [0]})}
+        )
+
+    monkeypatch.setattr(
+        "llm_behavior_eval.evaluation_utils.custom_dataset.load_dataset",
+        fake_load_dataset,
+    )
+    dataset = CustomDataset(
+        Path("/opt/assets/or-bench"),
+        DatasetType.BIAS,
+        dataset_id=OR_BENCH_DATASET,
+    )
+
+    assert loaded == ["/opt/assets/or-bench"]
+    assert dataset.dataset_id == OR_BENCH_DATASET
+
+
+def test_catalog_is_complete_and_expansions_are_unique() -> None:
+    presets = list_dataset_presets()
+
+    assert presets
+    assert len({preset.name for preset in presets}) == len(presets)
+    assert expand_dataset_preset("bias:all") == [
+        f"hirundo-io/bbq-{bias_type}-bias-free-text"
+        for bias_type in sorted(
+            {"age", "gender", "nationality", "physical", "race", "religion"}
+        )
+    ]
+    assert expand_dataset_preset("refusal:all") == [
+        "hirundo-io/XSTest",
+        "hirundo-io/or-bench",
+    ]

--- a/tests/test_dataset_identity.py
+++ b/tests/test_dataset_identity.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from datasets import Dataset, DatasetDict
+from pydantic import ValidationError
 
 from llm_behavior_eval import (
     DatasetConfig,
@@ -32,6 +33,18 @@ def test_dataset_id_assignment_cannot_leave_none() -> None:
     config.dataset_id = None  # type: ignore[assignment]
 
     assert config.dataset_id == config.file_path
+
+
+@pytest.mark.parametrize("invalid_dataset_id", [0, False, []])
+def test_dataset_id_assignment_rejects_non_strings(invalid_dataset_id: object) -> None:
+    config = DatasetConfig(
+        file_path="hirundo-io/halueval", dataset_type=DatasetType.BIAS
+    )
+
+    with pytest.raises(ValidationError):
+        config.dataset_id = invalid_dataset_id  # type: ignore[assignment]
+
+    assert config.dataset_id == "hirundo-io/halueval"
 
 
 def test_local_source_dispatches_by_logical_dataset_id() -> None:

--- a/tests/test_dataset_identity.py
+++ b/tests/test_dataset_identity.py
@@ -12,8 +12,10 @@ from llm_behavior_eval import (
     expand_dataset_preset,
     list_dataset_presets,
 )
+from llm_behavior_eval.evaluation_utils import free_text_hallu_evaluator
 from llm_behavior_eval.evaluation_utils.base_evaluator import BaseEvaluator
 from llm_behavior_eval.evaluation_utils.custom_dataset import CustomDataset
+from llm_behavior_eval.evaluation_utils.eval_config import EvaluationConfig
 from llm_behavior_eval.evaluation_utils.refusal_utils import OR_BENCH_DATASET
 
 
@@ -23,6 +25,11 @@ def test_dataset_id_defaults_to_loading_source() -> None:
     )
 
     assert config.dataset_id == config.file_path
+
+
+def test_missing_file_path_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        DatasetConfig(dataset_type=DatasetType.BIAS)  # type: ignore[call-arg]
 
 
 def test_dataset_id_assignment_cannot_leave_none() -> None:
@@ -56,6 +63,35 @@ def test_local_source_dispatches_by_logical_dataset_id() -> None:
 
     assert config.dataset_id is not None
     assert EvaluateFactory.get_evaluator_family(config.dataset_id) == "hallucination"
+
+
+def test_create_evaluator_dispatches_local_source_by_logical_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    marker = object()
+    captured: list[DatasetConfig] = []
+
+    def fake_evaluator(
+        _eval_config: EvaluationConfig, dataset_config: DatasetConfig
+    ) -> object:
+        captured.append(dataset_config)
+        return marker
+
+    monkeypatch.setattr(
+        free_text_hallu_evaluator, "FreeTextHaluEvaluator", fake_evaluator
+    )
+    config = DatasetConfig(
+        file_path="/opt/assets/halueval",
+        dataset_id="hirundo-io/halueval",
+        dataset_type=DatasetType.BIAS,
+    )
+
+    evaluator = EvaluateFactory.create_evaluator(
+        EvaluationConfig(model_path_or_repo_id="model", results_dir=tmp_path), config
+    )
+
+    assert evaluator is marker
+    assert captured == [config]
 
 
 def test_output_and_provenance_retain_logical_identity() -> None:


### PR DESCRIPTION
# User description
Linear: LLM-120

## Summary
- add a backward-compatible logical `dataset_id` distinct from the physical `file_path` loading source
- use canonical identity for dispatch, refusal handling, output naming, metrics, and provenance
- expose and document a public preset catalog with complete dataset expansions
- add regression coverage for local loading, identity semantics, compatibility, provenance, and catalog completeness

## Validation
- `.venv/bin/ruff format --check --diff`
- `.venv/bin/ruff check .`
- `.venv/bin/python -m pytest -q` (190 passed)
- `.venv/bin/pyrefly check` (changed code clean; repository-wide check reports missing optional mlflow/vllm/GitPython dependencies)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Separate dataset identity from the local or remote loading source by adding <code>dataset_id</code> to <code>DatasetConfig</code> and wiring <code>EvaluateFactory</code>, <code>BaseEvaluator</code>, and <code>CustomDataset</code> to use canonical IDs for dispatch, output naming, metrics, and provenance while still loading from <code>file_path</code>. Publish <code>llm_behavior_eval.presets</code> and reuse its catalog helpers in preset resolution so offline release tooling can enumerate complete dataset expansions without private CLI internals.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/150?tool=ast&topic=Preset+catalog>Preset catalog</a>
        </td><td>Expose the preset catalog as a public API and use it to expand CLI-style dataset shortcuts into the full canonical dataset list for offline bundling.<details><summary>Modified files (5)</summary><ul><li>docs/index.rst</li>
<li>llm_behavior_eval/__init__.py</li>
<li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/presets.py</li>
<li>tests/test_dataset_identity.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Clarify bias preset ex...</td><td>July 16, 2026</td></tr>
<tr><td>Ilagri</td><td>Add Bloom gender and r...</td><td>June 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/150?tool=ast&topic=Dataset+identity>Dataset identity</a>
        </td><td>Separate loading sources from logical dataset IDs so evaluators, refusal handling, output slugs, metrics, and provenance use the canonical identity while loaders keep using the physical path.<details><summary>Modified files (9)</summary><ul><li>llm_behavior_eval/evaluate.py</li>
<li>llm_behavior_eval/evaluation_utils/base_evaluator.py</li>
<li>llm_behavior_eval/evaluation_utils/custom_dataset.py</li>
<li>llm_behavior_eval/evaluation_utils/dataset_config.py</li>
<li>llm_behavior_eval/evaluation_utils/evaluate_factory.py</li>
<li>llm_behavior_eval/evaluation_utils/free_text_refusal_evaluator.py</li>
<li>tests/test_base_evaluator.py</li>
<li>tests/test_dataset.py</li>
<li>tests/test_dataset_identity.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Clarify bias preset ex...</td><td>July 16, 2026</td></tr>
<tr><td>Ilagri</td><td>Add Bloom gender and r...</td><td>June 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/150?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>