### PR TITLE
LLM-123: Fix Sphinx docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -20,6 +20,9 @@ concurrency:
 
 jobs:
   deploy-docs:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
   "ruff>=0.11.11,<1.0.0",
   "bumpver>=2024.1130",
   "pytest>=8.3.5",
+  "pyyaml>=6.0.2",
   "pre-commit>=4.3.0",
   "llm-behavior-eval[mlflow,vllm,gcs,azure]",
   "pyrefly>=0.63.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
   "pre-commit>=4.3.0",
   "llm-behavior-eval[mlflow,vllm,gcs,azure]",
   "pyrefly>=0.63.1",
+  "types-PyYAML",
   "types-tqdm",
 ]
 docs = ["sphinx>=8.0.0"]

--- a/tests/test_deploy_docs_workflow.py
+++ b/tests/test_deploy_docs_workflow.py
@@ -1,16 +1,14 @@
 from pathlib import Path
 
+import yaml
+
 
 def test_docs_deployment_requires_merged_release_pr() -> None:
-    workflow = Path(".github/workflows/deploy-docs.yaml").read_text()
+    workflow_text = Path(".github/workflows/deploy-docs.yaml").read_text()
+    workflow = yaml.safe_load(workflow_text)
+    condition = workflow["jobs"]["deploy-docs"]["if"]
 
-    assert (
-        """  deploy-docs:
-    if: >-
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release')
-"""
-        in workflow
-    )
-    assert 'pip install "llm-behavior-eval==${VERSION}"' in workflow
-    assert "test.pypi.org" not in workflow
+    assert "github.event.pull_request.merged == true" in condition
+    assert "contains(github.event.pull_request.labels.*.name, 'release')" in condition
+    assert 'pip install "llm-behavior-eval==${VERSION}"' in workflow_text
+    assert "test.pypi.org" not in workflow_text

--- a/tests/test_deploy_docs_workflow.py
+++ b/tests/test_deploy_docs_workflow.py
@@ -4,10 +4,13 @@ from pathlib import Path
 def test_docs_deployment_requires_merged_release_pr() -> None:
     workflow = Path(".github/workflows/deploy-docs.yaml").read_text()
 
-    assert """  deploy-docs:
+    assert (
+        """  deploy-docs:
     if: >-
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release')
-""" in workflow
+"""
+        in workflow
+    )
     assert 'pip install "llm-behavior-eval==${VERSION}"' in workflow
     assert "test.pypi.org" not in workflow

--- a/tests/test_deploy_docs_workflow.py
+++ b/tests/test_deploy_docs_workflow.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_docs_deployment_requires_merged_release_pr() -> None:
+    workflow = Path(".github/workflows/deploy-docs.yaml").read_text()
+
+    assert """  deploy-docs:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+""" in workflow
+    assert 'pip install "llm-behavior-eval==${VERSION}"' in workflow
+    assert "test.pypi.org" not in workflow

--- a/uv.lock
+++ b/uv.lock
@@ -2482,6 +2482,7 @@ dev = [
     { name = "pytest" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
     { name = "types-tqdm" },
 ]
 docs = [
@@ -2522,6 +2523,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", specifier = ">=0.11.11,<1.0.0" },
+    { name = "types-pyyaml" },
     { name = "types-tqdm" },
 ]
 docs = [{ name = "sphinx", marker = "python_full_version >= '3.11.4'", specifier = ">=8.0.0" }]
@@ -6159,6 +6161,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2480,6 +2480,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyrefly" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-tqdm" },
 ]
@@ -2519,6 +2520,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyrefly", specifier = ">=0.63.1" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", specifier = ">=0.11.11,<1.0.0" },
     { name = "types-tqdm" },
 ]


### PR DESCRIPTION
# User description
Closes LLM-123

## Summary
- require closed PRs to be merged before the docs job runs
- restrict production docs deployment to PRs labeled `release`
- add regression coverage for the deployment gate and production PyPI install path

## Validation
- `uvx --from pytest pytest tests/test_deploy_docs_workflow.py` (passed)
- `uvx ruff check tests/test_deploy_docs_workflow.py` (passed)
- Ruby YAML parse of `.github/workflows/deploy-docs.yaml` (passed)
- `git diff --check` (passed)

## Notes
- Full project environment sync is blocked on macOS ARM because locked `nvidia-cudnn-frontend==1.17.0` has no compatible wheel; the isolated regression test does not require the project dependency set.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Gate the <code>deploy-docs</code> GitHub Actions job so it only runs for merged PRs labeled <code>release</code>, preventing production docs deploys from unmerged or non-release changes. Add regression coverage that validates the workflow condition and confirms the production PyPI install path is used instead of TestPyPI.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/153?tool=ast&topic=Workflow+tests>Workflow tests</a>
        </td><td>Add workflow validation tests and YAML parsing support to lock in the deployment guard and production package install behavior.<details><summary>Modified files (3)</summary><ul><li>pyproject.toml</li>
<li>tests/test_deploy_docs_workflow.py</li>
<li>uv.lock</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Add PyYAML stubs for t...</td><td>July 20, 2026</td></tr>
<tr><td>orr@hirundo.io</td><td>Add Optional Dependenc...</td><td>June 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/Hirundo-io/llm-behavior-eval/153?tool=ast&topic=Deployment+gate>Deployment gate</a>
        </td><td>Restrict the docs deployment workflow to merged <code>release</code> PRs so <code>deploy-docs</code> only publishes production pages for approved releases.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/deploy-docs.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mishana4life@gmail.com</td><td>Fix docs deployment ga...</td><td>July 20, 2026</td></tr>
<tr><td>blewis@hirundo.io</td><td>Add `mlflow` support (...</td><td>October 12, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/Hirundo-io/llm-behavior-eval/153?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>